### PR TITLE
wip: conditionally allow setting event participant status on create only

### DIFF
--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -54,8 +54,8 @@ module Nylas
       # Serialize the object to an API-compatible JSON string
       # @param keys [Array<String>] The keys included
       # @return [String] The serialized object as a JSON string
-      def serialize_for_api(keys: attribute_definitions.keys)
-        serialize(keys: keys, enforce_read_only: true)
+      def serialize_for_api(keys: attribute_definitions.keys, enforce_read_only: true)
+        serialize(keys: keys, enforce_read_only: enforce_read_only)
       end
 
       def serialize_all_for_api(keys: attribute_definitions.keys)
@@ -86,11 +86,18 @@ module Nylas
       # @return [nil | Hash] The appropriately serialized value
       def attribute_to_hash(key, enforce_read_only)
         attribute_definition = attribute_definitions[key]
-        if enforce_read_only
-          attribute_definition.read_only == true ? nil : attribute_definition.serialize_for_api(self[key])
+        enforce_read_only_value = enforce_read_only_for_key(enforce_read_only, key: key)
+        if enforce_read_only_value
+          attribute_definition.read_only == true ? nil : attribute_definition.serialize_for_api(self[key], enforce_read_only: enforce_read_only_value)
         else
-          attribute_definition.serialize(self[key])
+          attribute_definition.serialize(self[key], enforce_read_only: enforce_read_only_value)
         end
+      end
+
+      def enforce_read_only_for_key(enforce_read_only_value, key:)
+        return enforce_read_only_value if [true, false].include?(enforce_read_only_value)
+
+        enforce_read_only_value.to_h.fetch(key){ false }
       end
     end
   end

--- a/lib/nylas/model/list_attribute_definition.rb
+++ b/lib/nylas/model/list_attribute_definition.rb
@@ -20,15 +20,11 @@ module Nylas
 
       def serialize(list, enforce_read_only: false)
         list = default if list.nil? || list.empty?
-        if enforce_read_only
-          list.map { |item| type.serialize_for_api(item) }
-        else
-          list.map { |item| type.serialize(item) }
-        end
+        list.map { |item| type.serialize_for_api(item, enforce_read_only: enforce_read_only) }
       end
 
-      def serialize_for_api(list)
-        serialize(list, enforce_read_only: true)
+      def serialize_for_api(list, enforce_read_only: true)
+        serialize(list, enforce_read_only: enforce_read_only)
       end
 
       def type

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -13,7 +13,7 @@ module Nylas
         object
       end
 
-      def serialize(object)
+      def serialize(object, enforce_read_only: false)
         object
       end
 
@@ -21,14 +21,14 @@ module Nylas
         object
       end
 
-      def serialize_for_api(object)
+      def serialize_for_api(object, enforce_read_only: true)
         serialize(object)
       end
     end
 
     # Casts/Serializes data that is persisted and used natively as a Hash
     class HashType < ValueType
-      def serialize(object)
+      def serialize(object, enforce_read_only: false)
         object.to_h
       end
 
@@ -49,12 +49,12 @@ module Nylas
         self.model = model
       end
 
-      def serialize(object)
+      def serialize(object, enforce_read_only: false)
         object.to_h
       end
 
-      def serialize_for_api(object)
-        object&.to_h(enforce_read_only: true)
+      def serialize_for_api(object, enforce_read_only: true)
+        object&.to_h(enforce_read_only: enforce_read_only)
       end
 
       def cast(value)
@@ -95,7 +95,7 @@ module Nylas
         cast(object)
       end
 
-      def serialize(object)
+      def serialize(object, enforce_read_only: false)
         return nil if object.nil?
 
         object.to_i
@@ -111,7 +111,7 @@ module Nylas
         Date.parse(value)
       end
 
-      def serialize(value)
+      def serialize(value, enforce_read_only: false)
         return value.iso8601 if value.respond_to?(:iso8601)
 
         value


### PR DESCRIPTION
This was the result of me trying to exercise and figure out how Nylas's event API works with setting participant status. See this thread in Slack for more context:
https://kajabi.slack.com/archives/C03FERRQGPR/p1661458850832249

No specs, just implementation. I didn't smoke test against this either; just tested locally. This isn't intended to ever be merged, just for reference.