### PR TITLE
Namespace Changes for Nylas -> Nylasv2

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -47,3 +47,8 @@ jobs:
 
     - name: Run tests
       run: bundle exec rspec spec
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: coverage/coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tags
 TAGS
 *.swp
 vendor/
+out

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -72,6 +72,7 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/nylas/http_client.rb'
+    - 'lib/nylas/when.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 * Add timezone fields to the `When` class
+* Adds visibility attribute to `Event` class
 
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API
@@ -88,8 +89,8 @@
 * Add support for read only attributes
 * Add `save_all_attributes` and `update_all_attributes` methods to support
   nullifying attributes.
-* Add support new `Event` metadata feature  
-* Fix attributes assignment for `Delta`  
+* Add support new `Event` metadata feature
+* Fix attributes assignment for `Delta`
 * Fix issue where files couldn't be attached to drafts
 * Fix exception raise when content-type is not JSON
 * Fix issue where draft version wouldn't update after `update` or `save`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 * Add timezone fields to the `When` class
 * Adds visibility attribute to `Event` class
+* Add support for calendar colors (for Microsoft calendars)
 
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+### 5.13.0 / 2022-10-21
 * Add timezone fields to the `When` class
 * Adds visibility attribute to `Event` class
 * Add support for calendar colors (for Microsoft calendars)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Added support for rate limit errors
+
 ### 5.13.0 / 2022-10-21
 * Add timezone fields to the `When` class
 * Adds visibility attribute to `Event` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-### Unreleased
+### 5.14.0 / 2022-12-16
 * Added support for rate limit errors
+* Added `disable_provider_selection` option for building auth URL
+* Improved performance by skipping creating instance of StringIO before parsing JSON
 
 ### 5.13.0 / 2022-10-21
 * Add timezone fields to the `When` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Unreleased
+* Add timezone fields to the `When` class
+
 ### 5.12.1 / 2022-08-12
 * Add support for getting `ids` and `count` for collections not supported by the API
 * Fix Ruby 3.x compatibility for expanding keyword arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * Add Outbox support
 * Add new `authentication_type` field in Account
 * Add support for basic authentication
-* Enable Nylas API v2.5 support
+* Enable NylasV2 API v2.5 support
 
 ### 5.8.0 / 2022-03-18
 * Improved support for `Webhook` objects
@@ -82,7 +82,7 @@
 ### 5.3.0 / 2021-08-18
 * Add support for Neural API
 * Fix issue where `Delta` did not have a header attribute for expanded headers
-* Fix ArgumentError when calling `Nylas::API#send!` due to missing double splat (**)
+* Fix ArgumentError when calling `NylasV2::API#send!` due to missing double splat (**)
 * Fix issue where server errors are not reported if HTML is returned
 * Fix issue where expanded `Thread` objects were not returning messages
 
@@ -103,7 +103,7 @@
 
 ### 5.0.0 / 2021-05-07
 
-* Send `Nylas-API-Version` header to API with latest supported version.
+* Send `NylasV2-API-Version` header to API with latest supported version.
 * Fix issue sending message using raw mime type.
 * Support for `messages.expanded.find(id)` to return expanded message.
 * Add support for hosted authentication
@@ -163,7 +163,7 @@
 * Fix issue when calling `.save` on `message` (https://github.com/nylas/nylas-ruby/pull/233)
 * Add support for Rails 6.
 * Fix issue for updating `message` with sending `label_ids` (https://github.com/nylas/nylas-ruby/pull/231)
-* Support for `when` in `Nylas::Event` for more attributes.
+* Support for `when` in `NylasV2::Event` for more attributes.
 * Add internal transfer api to support initialize related objects.
 * Fix encoding issues when downloading attachments.
 
@@ -183,10 +183,10 @@
 
 * Drop support for Ruby 2.2 and 2.3: they have reached end-of-life
 * Add support for Ruby 2.5 and 2.6
-* Add `scopes` argument to `Nylas::API#authenticate` for
+* Add `scopes` argument to `NylasV2::API#authenticate` for
   [selective sync](https://docs.nylas.com/docs/how-to-use-selective-sync)
 * Add `Account#revoke_all`
-* Add X-Nylas-Client-Id header for HTTP requests
+* Add X-NylasV2-Client-Id header for HTTP requests
 
 ### 4.2.4 / 2018-08-07
 * Enables silent addition of fields to API without impact to SDK
@@ -240,7 +240,7 @@
 
 * Deprecate the tags API
 * Remove the archive!/unarchive! methods
-* Expose `starred`, `unread`, `has_attachments` in Nylas::Thread
+* Expose `starred`, `unread`, `has_attachments` in NylasV2::Thread
 
 [full changelog](https://github.com/nylas/nylas-ruby/compare/v1.2.1...v1.3.0)
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,11 +1,11 @@
-# Contribute to Nylas
+# Contribute to NylasV2
 👍  🎉  First of all, thanks for taking the time to contribute! 🎉  👍
 
-The following is a set of guidelines for contributing to the Nylas Ruby SDK; these are guidelines, not rules, so please use your best judgement and feel free to propose changes to this document via pull request.
+The following is a set of guidelines for contributing to the NylasV2 Ruby SDK; these are guidelines, not rules, so please use your best judgement and feel free to propose changes to this document via pull request.
 
 # How to Ask a Question
 
-If you have a question about how to use the Ruby SDK, please [create an issue](https://github.com/nylas/nylas-ruby/issues) and label it as a question. If you have more general questions about the Nylas Communications Platform, or the Nylas Email, Calendar, and Contacts API, please reach out to support@nylas.com to get help.
+If you have a question about how to use the Ruby SDK, please [create an issue](https://github.com/nylas/nylas-ruby/issues) and label it as a question. If you have more general questions about the NylasV2 Communications Platform, or the NylasV2 Email, Calendar, and Contacts API, please reach out to support@nylas.com to get help.
 
 # How To Contribute
 ## Report a Bug or Request a Feature

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 ----
 
-Copyright (c) 2016 Nylas, Inc. and Contributors
+Copyright (c) 2016 NylasV2, Inc. and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<a href="https://www.nylas.com/">
+    <img src="https://brand.nylas.com/assets/downloads/logo_horizontal_png/Nylas-Logo-Horizontal-Blue_.png" alt="Aimeos logo" title="Aimeos" align="right" height="60" />
+</a>
+
 # Nylas Ruby SDK
+
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nylas/nylas-ruby/CI)](https://github.com/nylas/nylas-ruby/actions/workflows/rspec.yml)
+[![codecov](https://codecov.io/gh/nylas/nylas-ruby/branch/main/graph/badge.svg?token=IKH0YMH4KA)](https://codecov.io/gh/nylas/nylas-ruby)
+
 The Nylas Communications Platform allows developers to quickly build features that connect to every inbox, calendar, and contacts book in the world. Nylas makes it easy to build an integration that can be completed in days, and provides pre-built security and compliance features, and a 99.9% guaranteed uptime. Integrations with the Nylas Communications Platform are secure, reliable, and easy to use and maintain.
 
 Nylas provides REST APIs for [Email](https://docs.nylas.com/docs/quickstart-email), [Calendar](https://docs.nylas.com/docs/quickstart-calendar), and [Contacts](https://docs.nylas.com/docs/quickstart-contacts), and the Ruby SDK is the quickest way to build your first integration using Ruby.
@@ -13,73 +21,42 @@ Here are some additional resources to help you get started:
 - [Nylas API Reference](https://docs.nylas.com/reference)
 
 If you have a question that needs an answer, please reach out to support@nylas.com to get help.
-[](https://nylas.com/register)
-# Install
-## Prerequisites
+
+## ⚙️ Install
+### Prerequisites
 - Ruby 2.3 or above.
 - Ruby Frameworks: `rest-client`, `json`, `yajl-ruby`.
 
 We support Rails 4.2 and above. A more detailed compatibility list can be found in our [list of Gemfiles](https://github.com/nylas/nylas-ruby/tree/master/gemfiles).
 
-## Install
+### Install
 
 Add this line to your application's Gemfile:
 
-    gem 'nylas'
+```ruby
+gem 'nylas'
+```
 
 And then execute:
 
-    bundle
+```bash
+bundle
+```
 
 To run scripts that use the Nylas Ruby SDK, install the nylas gem.
 
-    gem install nylas
-
-To install the SDK from source, clone this repo and install with bundle.
-
-    git clone https://github.com/nylas/nylas-ruby.git && cd nylas-ruby
-    bundle install
-    
-## MacOS 10.11 (El Capitan) Note
-
-Apple stopped bundling OpenSSL with MacOS 10.11. However, one of the dependencies of this gem (EventMachine) requires it. If you're on El Capitan and are unable to install the gem, try running the following commands in a terminal:
-
-```
-sudo brew install openssl
-sudo brew link openssl --force
+```bash
 gem install nylas
 ```
 
-# Usage
+To install the SDK from source, clone this repo and install with bundle.
 
-To use this SDK, you first need to [sign up for a free Nylas developer account](https://nylas.com/register).
+```bash
+git clone https://github.com/nylas/nylas-ruby.git && cd nylas-ruby
+bundle install
+```
 
-Then, follow our guide to [setup your first app and get your API access keys](https://docs.nylas.com/docs/get-your-developer-api-keys).
-
-All of the functionality of the Nylas Communications Platform is available through the `API` object. To access data for an account that’s connected to Nylas, create a new API client object and pass the variables you gathered when you got your developer API keys. In the following example, replace `CLIENT_ID`, `CLIENT_SECRET`, and `ACCESS_TOKEN` with your values.
-
-
-    require 'nylas'
-    
-    nylas = Nylas::API.new(
-        app_id: CLIENT_ID,
-        app_secret: CLIENT_SECRET,
-        access_token: ACCESS_TOKEN
-    )
-
-Now, you can use `nylas` to access full email, calendar, and contacts functionality. For example, here is how you would print the subject line for the most recent email message to the console.
-
-
-    message = nylas.messages.first
-    puts(message.subject)
-
-To learn more about how to use the Nylas Ruby SDK, please refer to our [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK QuickStart Guide](https://docs.nylas.com/docs/quickstart-ruby).
-
-# Contributing
-
-Please refer to [Contributing](Contributing.md) for information about how to make contributions to this project. We welcome questions, bug reports, and pull requests.
-
-## Setup Ruby SDK for Development
+### Setup Ruby SDK for Development
 
 Install [RubyGems](https://rubygems.org/pages/download) if you don't already have it:
 
@@ -99,7 +76,50 @@ You can run tests locally using ```rspec```:
 ```shell
 rspec spec
 ```
+    
+### MacOS 10.11 (El Capitan) Note
 
-# License
+Apple stopped bundling OpenSSL with MacOS 10.11. However, one of the dependencies of this gem (EventMachine) requires it. If you're on El Capitan and are unable to install the gem, try running the following commands in a terminal:
+
+```bash
+sudo brew install openssl
+sudo brew link openssl --force
+gem install nylas
+```
+
+## ⚡️ Usage
+
+To use this SDK, you first need to [sign up for a free Nylas developer account](https://nylas.com/register).
+
+Then, follow our guide to [setup your first app and get your API access keys](https://docs.nylas.com/docs/get-your-developer-api-keys).
+
+All of the functionality of the Nylas Communications Platform is available through the `API` object. To access data for an account that’s connected to Nylas, create a new API client object and pass the variables you gathered when you got your developer API keys. In the following example, replace `CLIENT_ID`, `CLIENT_SECRET`, and `ACCESS_TOKEN` with your values.
+
+
+```ruby
+require 'nylas'
+
+nylas = Nylas::API.new(
+    app_id: CLIENT_ID,
+    app_secret: CLIENT_SECRET,
+    access_token: ACCESS_TOKEN
+)
+```
+
+Now, you can use `nylas` to access full email, calendar, and contacts functionality. For example, here is how you would print the subject line for the most recent email message to the console.
+
+
+```ruby
+message = nylas.messages.first
+puts(message.subject)
+```
+
+To learn more about how to use the Nylas Ruby SDK, please refer to our [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK QuickStart Guide](https://docs.nylas.com/docs/quickstart-ruby).
+
+## 💙 Contributing
+
+Please refer to [Contributing](Contributing.md) for information about how to make contributions to this project. We welcome questions, bug reports, and pull requests.
+
+## 📝 License
 
 This project is licensed under the terms of the MIT license. Please refer to [LICENSE](LICENSE.txt) for the full terms. 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 <a href="https://www.nylas.com/">
-    <img src="https://brand.nylas.com/assets/downloads/logo_horizontal_png/Nylas-Logo-Horizontal-Blue_.png" alt="Aimeos logo" title="Aimeos" align="right" height="60" />
+    <img src="https://brand.nylas.com/assets/downloads/logo_horizontal_png/NylasV2-Logo-Horizontal-Blue_.png" alt="Aimeos logo" title="Aimeos" align="right" height="60" />
 </a>
 
-# Nylas Ruby SDK
+# NylasV2 Ruby SDK
 
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/nylas/nylas-ruby/CI)](https://github.com/nylas/nylas-ruby/actions/workflows/rspec.yml)
 [![codecov](https://codecov.io/gh/nylas/nylas-ruby/branch/main/graph/badge.svg?token=IKH0YMH4KA)](https://codecov.io/gh/nylas/nylas-ruby)
 
-The Nylas Communications Platform allows developers to quickly build features that connect to every inbox, calendar, and contacts book in the world. Nylas makes it easy to build an integration that can be completed in days, and provides pre-built security and compliance features, and a 99.9% guaranteed uptime. Integrations with the Nylas Communications Platform are secure, reliable, and easy to use and maintain.
+The NylasV2 Communications Platform allows developers to quickly build features that connect to every inbox, calendar, and contacts book in the world. NylasV2 makes it easy to build an integration that can be completed in days, and provides pre-built security and compliance features, and a 99.9% guaranteed uptime. Integrations with the NylasV2 Communications Platform are secure, reliable, and easy to use and maintain.
 
-Nylas provides REST APIs for [Email](https://docs.nylas.com/docs/quickstart-email), [Calendar](https://docs.nylas.com/docs/quickstart-calendar), and [Contacts](https://docs.nylas.com/docs/quickstart-contacts), and the Ruby SDK is the quickest way to build your first integration using Ruby.
+NylasV2 provides REST APIs for [Email](https://docs.nylas.com/docs/quickstart-email), [Calendar](https://docs.nylas.com/docs/quickstart-calendar), and [Contacts](https://docs.nylas.com/docs/quickstart-contacts), and the Ruby SDK is the quickest way to build your first integration using Ruby.
 
-This is the GitHub repository for the Nylas Ruby SDK and is primarily for anyone who wants to make contributions to the SDK or install it from source. If you are looking to use Ruby to access the Nylas Email, Calendar, or Contacts API you should refer to our official [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK Quickstart Guide](https://docs.nylas.com/docs/quickstart-ruby).
+This is the GitHub repository for the NylasV2 Ruby SDK and is primarily for anyone who wants to make contributions to the SDK or install it from source. If you are looking to use Ruby to access the NylasV2 Email, Calendar, or Contacts API you should refer to our official [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK Quickstart Guide](https://docs.nylas.com/docs/quickstart-ruby).
 
 Here are some additional resources to help you get started:
 
-- [Nylas SDK Tutorials](https://docs.nylas.com/docs/tutorials)
-- [Get Started with the Nylas Communications Platform](https://docs.nylas.com/docs/getting-started)
-- [Sign up for your Nylas developer account.](https://nylas.com/register)
-- [Nylas API Reference](https://docs.nylas.com/reference)
+- [NylasV2 SDK Tutorials](https://docs.nylas.com/docs/tutorials)
+- [Get Started with the NylasV2 Communications Platform](https://docs.nylas.com/docs/getting-started)
+- [Sign up for your NylasV2 developer account.](https://nylas.com/register)
+- [NylasV2 API Reference](https://docs.nylas.com/reference)
 
 If you have a question that needs an answer, please reach out to support@nylas.com to get help.
 
@@ -43,7 +43,7 @@ And then execute:
 bundle
 ```
 
-To run scripts that use the Nylas Ruby SDK, install the nylas gem.
+To run scripts that use the NylasV2 Ruby SDK, install the nylas gem.
 
 ```bash
 gem install nylas
@@ -89,17 +89,17 @@ gem install nylas
 
 ## ⚡️ Usage
 
-To use this SDK, you first need to [sign up for a free Nylas developer account](https://nylas.com/register).
+To use this SDK, you first need to [sign up for a free NylasV2 developer account](https://nylas.com/register).
 
 Then, follow our guide to [setup your first app and get your API access keys](https://docs.nylas.com/docs/get-your-developer-api-keys).
 
-All of the functionality of the Nylas Communications Platform is available through the `API` object. To access data for an account that’s connected to Nylas, create a new API client object and pass the variables you gathered when you got your developer API keys. In the following example, replace `CLIENT_ID`, `CLIENT_SECRET`, and `ACCESS_TOKEN` with your values.
+All of the functionality of the NylasV2 Communications Platform is available through the `API` object. To access data for an account that’s connected to NylasV2, create a new API client object and pass the variables you gathered when you got your developer API keys. In the following example, replace `CLIENT_ID`, `CLIENT_SECRET`, and `ACCESS_TOKEN` with your values.
 
 
 ```ruby
 require 'nylas'
 
-nylas = Nylas::API.new(
+nylas = NylasV2::API.new(
     app_id: CLIENT_ID,
     app_secret: CLIENT_SECRET,
     access_token: ACCESS_TOKEN
@@ -114,7 +114,7 @@ message = nylas.messages.first
 puts(message.subject)
 ```
 
-To learn more about how to use the Nylas Ruby SDK, please refer to our [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK QuickStart Guide](https://docs.nylas.com/docs/quickstart-ruby).
+To learn more about how to use the NylasV2 Ruby SDK, please refer to our [Ruby](https://docs.nylas.com/docs/quickstart-ruby) [SDK QuickStart Guide](https://docs.nylas.com/docs/quickstart-ruby).
 
 ## 💙 Contributing
 

--- a/bin/release
+++ b/bin/release
@@ -2,7 +2,7 @@
 set -e
 
 bin/test
-SDK_VERSION=`ruby -e "require './lib/nylas/version' ; puts Nylas::VERSION"`
+SDK_VERSION=`ruby -e "require './lib/nylas/version' ; puts NylasV2::VERSION"`
 echo "Going to release version $SDK_VERSION of the SDK!"
 
 gem build nylas.gemspec

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,17 +1,17 @@
 # Authentication
 
-Nylas supports two forms of authentication:
+NylasV2 supports two forms of authentication:
 
-* Native Authentication, where the developer is responsible for building the user interface for retrieiving the appropriate credentials for a users contacts, mail and/or calendar provider. See the [Nylas Native Authentication Reference Documentation](https://docs.nylas.com/reference#native-authentication-1) for more details.
+* Native Authentication, where the developer is responsible for building the user interface for retrieiving the appropriate credentials for a users contacts, mail and/or calendar provider. See the [NylasV2 Native Authentication Reference Documentation](https://docs.nylas.com/reference#native-authentication-1) for more details.
 
-* Nylas OAuth, where Nylas acts as an OAuth Provider that abstracts away the supported providers. This allows you to get up and running quickly without having to build potentially complex user interfaces for supporting any number of providers. See the [Nylas OAuth Authentication Reference Documentation](https://docs.nylas.com/reference#oauth) for more details.
+* NylasV2 OAuth, where NylasV2 acts as an OAuth Provider that abstracts away the supported providers. This allows you to get up and running quickly without having to build potentially complex user interfaces for supporting any number of providers. See the [NylasV2 OAuth Authentication Reference Documentation](https://docs.nylas.com/reference#oauth) for more details.
 
 ## Running the Example
 
 1. Clone the repository
 1. Install the dependencies by using `bundle install`
-1. Get a Nylas App ID and App Secret from the [Nylas Dashboard](https://dashboard.nylas.com/)
-1. Get a Google Cloud Platform Access Token by following the [Nylas Google Setup Guide](https://docs.nylas.com/docs/creating-a-google-project-for-dev). Make sure to set the callback to `localhost:4567/auth/google/callback`.
+1. Get a NylasV2 App ID and App Secret from the [NylasV2 Dashboard](https://dashboard.nylas.com/)
+1. Get a Google Cloud Platform Access Token by following the [NylasV2 Google Setup Guide](https://docs.nylas.com/docs/creating-a-google-project-for-dev). Make sure to set the callback to `localhost:4567/auth/google/callback`.
 1. Copy `.env.example` to `.env` and set the values based upon the previous steps.
 1. Run the app web server: `bundle exec dotenv ruby app.rb`
 1. Login to whichever mail, contact, and calendaring providers you want using the different authentication mechanisms.

--- a/examples/authentication/app.rb
+++ b/examples/authentication/app.rb
@@ -24,7 +24,7 @@ end
   send(method, "/auth/:provider/callback") do
     auth_hash = env['omniauth.auth'] # => OmniAuth::AuthHash
 
-    api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+    api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
     nylas_token = api.authenticate(name: auth_hash[:info][:name], email_address: auth_hash[:info][:email],
                                    provider: :gmail,
                                    settings: { google_client_id: ENV['GOOGLE_CLIENT_ID'],

--- a/examples/listening-for-webhooks/README.md
+++ b/examples/listening-for-webhooks/README.md
@@ -6,7 +6,7 @@ then as the particular data as a hash
 
 1. Clone the repository
 1. Install the dependencies by using `bundle install`
-1. Get a Nylas App ID and App Secret from the [Nylas Dashboard](https://dashboard.nylas.com/)
+1. Get a NylasV2 App ID and App Secret from the [NylasV2 Dashboard](https://dashboard.nylas.com/)
 1. Run the app web server: `bundle exec ruby demo-app.rb`
 1. Use a service like `ngrok` to expose your local app server to the public internet.
 1. Set up a webhook to point to the public url for your local instance at the path `/webhook-event-received` by following the [instructions for creating a webhook](https://docs.nylas.com/v1.0/reference#creating-a-webhook).

--- a/examples/listening-for-webhooks/demo-app.rb
+++ b/examples/listening-for-webhooks/demo-app.rb
@@ -10,7 +10,7 @@ post '/webhook-event-received' do
   json = request.body.read
   logger.info ["json", json]
   data = JSON.parse(json, symbolize_names: true)
-  deltas = Nylas::Deltas.new(**data)
+  deltas = NylasV2::Deltas.new(**data)
   deltas.map do |delta|
     logger.info ["delta", delta.to_h]
     logger.info ["instance", delta.instance.class, delta.instance.to_h]

--- a/examples/plain-ruby/accounts.rb
+++ b/examples/plain-ruby/accounts.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving the account information for given access token

--- a/examples/plain-ruby/calendars.rb
+++ b/examples/plain-ruby/calendars.rb
@@ -1,9 +1,9 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Calendar API.
 # See https://docs.nylas.com/reference#calendars
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 

--- a/examples/plain-ruby/components.rb
+++ b/examples/plain-ruby/components.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
 
 # Create a component
 # NOTE: you will need to set the account_id and the access_token

--- a/examples/plain-ruby/contacts.rb
+++ b/examples/plain-ruby/contacts.rb
@@ -1,7 +1,7 @@
 require_relative '../helpers'
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 # Retrieving a count of contacts
 demonstrate { api.contacts.count }
@@ -66,7 +66,7 @@ contact_with_picture = api.contacts.where(email: 'contact-with-picture@example.c
 demonstrate { contact_with_picture.picture_url }
 begin
 demonstrate { contact_with_picture.picture }
-rescue Nylas::ResourceNotFound
+rescue NylasV2::ResourceNotFound
   puts "That contacts picture didn't propagate yet :/"
 end
 

--- a/examples/plain-ruby/deltas.rb
+++ b/examples/plain-ruby/deltas.rb
@@ -1,9 +1,9 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas #
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2 #
 # Deltas API.
 # See https://docs.nylas.com/reference#deltas
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 
@@ -27,7 +27,7 @@ demonstrate { deltas_from_cursor.find_each.map(&:id).count }
 # 5 delta's
 demonstrate { deltas_from_cursor.take(5).map(&:to_h) }
 
-# Models are cast to Nylas::Model objects
+# Models are cast to NylasV2::Model objects
 demonstrate { deltas_from_cursor.first&.model&.class }
 
 # And can be viewed directly

--- a/examples/plain-ruby/drafts.rb
+++ b/examples/plain-ruby/drafts.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Drafts API. See https://docs.nylas.com/reference#drafts for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Creating a draft

--- a/examples/plain-ruby/events.rb
+++ b/examples/plain-ruby/events.rb
@@ -1,9 +1,9 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Events API.
 # See https://docs.nylas.com/reference#events
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Counting the events

--- a/examples/plain-ruby/files.rb
+++ b/examples/plain-ruby/files.rb
@@ -1,9 +1,9 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas Files
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2 Files
 # API.
 # See https://docs.nylas.com/reference#files
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Listing files

--- a/examples/plain-ruby/folders.rb
+++ b/examples/plain-ruby/folders.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_FOLDER_USERS_ACCESS_TOKEN'])
 
 # Retrieving the count of folders

--- a/examples/plain-ruby/job_status.rb
+++ b/examples/plain-ruby/job_status.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Drafts API. See https://docs.nylas.com/reference#drafts for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Getting all job statuses

--- a/examples/plain-ruby/labels.rb
+++ b/examples/plain-ruby/labels.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving the count of labels

--- a/examples/plain-ruby/messages.rb
+++ b/examples/plain-ruby/messages.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Messages API. See https://docs.nylas.com/reference#messages for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving a count of messages
@@ -27,7 +27,7 @@ demonstrate { { starred: reloaded_message.starred, unread: reloaded_message.unre
 demonstrate do
   begin
     api.messages.create
-  rescue Nylas::ModelNotCreatableError => e
+  rescue NylasV2::ModelNotCreatableError => e
     "#{e.class}: #{e.message}"
   end
 end
@@ -37,7 +37,7 @@ message = api.messages.first
 demonstrate do
   begin
     message.destroy
-  rescue Nylas::ModelNotDestroyableError => e
+  rescue NylasV2::ModelNotDestroyableError => e
     "#{e.class}: #{e.message}"
   end
 end

--- a/examples/plain-ruby/neural.rb
+++ b/examples/plain-ruby/neural.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 message_id = api.messages.first.id
@@ -18,7 +18,7 @@ demonstrate { sentiments[0].to_h }
 # Perform extracting a signature and parsing its contact information
 signatures = api.neural.extract_signature([message_id])
 demonstrate { signatures[0].to_h }
-# Convert the parsed contact to a Nylas contact object
+# Convert the parsed contact to a NylasV2 contact object
 contact = signatures[0].contacts.to_contact_object
 demonstrate { contact.to_h }
 
@@ -33,7 +33,7 @@ else
     # Also just pass in the file ID without a range to perform OCR on all pages
     ocr = api.neural.ocr_request(file_id, [1])
     demonstrate { ocr.to_h }
-  rescue Nylas::Error => e
+  rescue NylasV2::Error => e
     puts "#{e.class}: #{e.message}"
   end
 end
@@ -49,7 +49,7 @@ demonstrate { categorize.to_h }
 conversations = api.neural.clean_conversation([message_id])
 demonstrate { conversations[0].to_h }
 # Provide some options to the endpoint
-options = Nylas::NeuralMessageOptions.new(ignore_images: false)
+options = NylasV2::NeuralMessageOptions.new(ignore_images: false)
 conversations = api.neural.clean_conversation([message_id], options)
 demonstrate { conversations[0].to_h }
 # Parse the images from the clean conversation

--- a/examples/plain-ruby/outbox.rb
+++ b/examples/plain-ruby/outbox.rb
@@ -1,13 +1,13 @@
 require_relative '../helpers'
 require 'date'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Prepare the draft and timestamps
-draft = Nylas::Draft.new(to: [{ email: ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-a-real-email@example.com'), name: "Me" }],
+draft = NylasV2::Draft.new(to: [{ email: ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-a-real-email@example.com'), name: "Me" }],
                           subject: "A new draft!",
                           metadata: {sdk: "Ruby SDK"})
 tomorrow = Date.today + 1

--- a/examples/plain-ruby/room_resource.rb
+++ b/examples/plain-ruby/room_resource.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Retrieving a list of room resources

--- a/examples/plain-ruby/scheduler.rb
+++ b/examples/plain-ruby/scheduler.rb
@@ -1,9 +1,9 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Scheduler API.
 # See https://developer.nylas.com/docs/api/scheduler/#overview
-nylas = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+nylas = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Create a scheduler page
@@ -32,14 +32,14 @@ demonstrate { example_scheduler.upload_image(content_type: "image/png", object_n
 # Get Google Availability
 begin
   demonstrate { nylas.scheduler.get_google_availability }
-rescue Nylas::Error => e
+rescue NylasV2::Error => e
   puts "#{e.class}: #{e.message}"
 end
 
 # Get Office 365 Availability
 begin
   demonstrate { nylas.scheduler.get_office_365_availability }
-rescue Nylas::Error => e
+rescue NylasV2::Error => e
   puts "#{e.class}: #{e.message}"
 end
 
@@ -51,7 +51,7 @@ available_timeslots = nylas.scheduler.get_available_time_slots(example_scheduler
 demonstrate { available_timeslots.inspect }
 
 # Book a timeslot
-booking_request = Nylas::SchedulerBookingRequest.new(
+booking_request = NylasV2::SchedulerBookingRequest.new(
   additional_values: {
     important: "true"
   },
@@ -70,7 +70,7 @@ demonstrate { nylas.scheduler.cancel_booking(example_scheduler.slug, booking_con
 # Confirm a booking (Expect an error because we already cancelled this meeting)
 begin
   demonstrate { nylas.scheduler.confirm_booking(example_scheduler.slug, booking_confirmation.edit_hash) }
-rescue Nylas::Error => e
+rescue NylasV2::Error => e
   puts "#{e.class}: #{e.message}"
 end
 

--- a/examples/plain-ruby/sending-messages.rb
+++ b/examples/plain-ruby/sending-messages.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to send messages via the API
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to send messages via the API
 # See https://docs.nylas.com/reference#sending
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 # Sending a message as a hash
@@ -15,7 +15,7 @@ end
 
 # Sending a message by instantiating a message instance
 demonstrate do
-  message = Nylas::NewMessage.new(to: [{ email: ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-a-real-email@example.com'),
+  message = NylasV2::NewMessage.new(to: [{ email: ENV.fetch('NYLAS_EXAMPLE_EMAIL', 'not-a-real-email@example.com'),
                                          name: "An example recipient" }],
                                   subject: "you've got another mail!",
                                   body: "It's a really good another mail!", api: api)

--- a/examples/plain-ruby/streaming.rb
+++ b/examples/plain-ruby/streaming.rb
@@ -1,6 +1,6 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to listen for streamed Deltas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to listen for streamed Deltas
 # See https://docs.nylas.com/reference#streaming-delta-updates
 require 'nylas-streaming'
 
@@ -16,9 +16,9 @@ def interactive_stream(include_types: [], exclude_types: [])
     end
     Signal.trap("TERM") { EventMachine.stop }
 
-    api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+    api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                          access_token: ENV['NYLAS_ACCESS_TOKEN'])
-    Nylas::Streaming.deltas(api: api, cursor: ENV['NYLAS_PREVIOUS_CURSOR'],
+    NylasV2::Streaming.deltas(api: api, cursor: ENV['NYLAS_PREVIOUS_CURSOR'],
                             include_types: include_types, exclude_types: exclude_types) do |delta|
       puts "#{delta.event} of #{delta.object} #{delta.model.id} as a #{delta.class}"
     end

--- a/examples/plain-ruby/threads.rb
+++ b/examples/plain-ruby/threads.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the API. It
-# follows the rough structure of the [Nylas API Reference](https://docs.nylas.com/reference).
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the API. It
+# follows the rough structure of the [NylasV2 API Reference](https://docs.nylas.com/reference).
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'],
                      access_token: ENV['NYLAS_ACCESS_TOKEN'])
 
 
@@ -25,7 +25,7 @@ demonstrate { { starred: reloaded_thread.starred, unread: reloaded_thread.unread
 demonstrate do
   begin
     api.threads.create
-  rescue Nylas::ModelNotCreatableError => e
+  rescue NylasV2::ModelNotCreatableError => e
     "#{e.class}: #{e.message}"
   end
 end
@@ -36,7 +36,7 @@ end
 demonstrate do
   begin
     thread.destroy
-  rescue Nylas::ModelNotDestroyableError => e
+  rescue NylasV2::ModelNotDestroyableError => e
     "#{e.class}: #{e.message}"
   end
 end

--- a/examples/plain-ruby/webhooks.rb
+++ b/examples/plain-ruby/webhooks.rb
@@ -1,8 +1,8 @@
 require_relative '../helpers'
 
-# An executable specification that demonstrates how to use the Nylas Ruby SDK to interact with the Nylas
+# An executable specification that demonstrates how to use the NylasV2 Ruby SDK to interact with the NylasV2
 # Webhooks API. See https://docs.nylas.com/reference#webhooks for API documentation
-api = Nylas::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
+api = NylasV2::API.new(app_id: ENV['NYLAS_APP_ID'], app_secret: ENV['NYLAS_APP_SECRET'])
 
 
 # Webhooks can be retrieved as a collection

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -52,6 +52,7 @@ module GemConfig
      ["webmock", "~> 3.0"],
      ["faker", "~> 1.8"],
      ["informed", "~> 1.0"],
-     ["simplecov", "~> 0.15"]]
+     ["simplecov", "~> 0.21.2"],
+     ["simplecov-cobertura", "~> 2.1.0"]]
   end
 end

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -40,6 +40,7 @@ module GemConfig
      ["awesome_print", "~> 1.0"],
      ["rubocop", "~> 1.24.1"],
      ["rubocop-rspec", "~> 2.7.0"],
+     ["tzinfo", "~> 2.0.5"],
      ["overcommit", "~> 0.41"]] + testing_and_debugging_dependencies
   end
 

--- a/gem_config.rb
+++ b/gem_config.rb
@@ -8,7 +8,7 @@ module GemConfig
     gem.name = name
     gem.files = Dir.glob("lib/{#{name}.rb,#{name}/**/*.rb}")
     gem.license = "MIT"
-    gem.version = Nylas::VERSION
+    gem.version = NylasV2::VERSION
     gem.platform = "ruby"
     gem.required_ruby_version = ">= 2.3"
     append_nylas_data(gem)
@@ -20,7 +20,7 @@ module GemConfig
   def self.append_nylas_data(gem)
     gem.metadata = metadata
     gem.email = "support@nylas.com"
-    gem.authors = ["Nylas, Inc."]
+    gem.authors = ["NylasV2, Inc."]
   end
 
   def self.metadata

--- a/gemfiles/Gemfile.rails5
+++ b/gemfiles/Gemfile.rails5
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5'
+gem 'rails', '>= 5.2.8.1'
 
 gemspec path: "..", name: 'nylas-streaming'

--- a/lib/nylas-streaming.rb
+++ b/lib/nylas-streaming.rb
@@ -4,11 +4,11 @@ require "yajl"
 require "em-http"
 require "nylas"
 
-module Nylas
-  # Provides methods to work with the Nylas Streaming Deltas API
+module NylasV2
+  # Provides methods to work with the NylasV2 Streaming Deltas API
   # @see https://docs.nylas.com/reference#streaming-delta-updates
   module Streaming
-    # @see Nylas::Streaming::DeltaStream#initialize
+    # @see NylasV2::Streaming::DeltaStream#initialize
     def self.deltas(**kwargs, &callback)
       DeltaStream.new(**kwargs).stream(&callback)
     end
@@ -19,7 +19,7 @@ module Nylas
                     :connect_timeout, :inactivity_timeout
 
       # @param cursor [String] Cursor to start listening for changes on
-      # @param api [Nylas::API]
+      # @param api [NylasV2::API]
       # @param expanded [Boolean] Expands threads and messages
       # @param exclude_types [Array<String>] List of Object types *not* to include in the stream
       # @param include_types [Array<String>] List of Object types to exclusively include in the stream
@@ -40,8 +40,8 @@ module Nylas
         parser.on_parse_complete = lambda do |data|
           begin
             yield(Types.registry[:delta].cast(data.merge(api: api)))
-          rescue Nylas::Error => e
-            Nylas::Logging.logger.error(e)
+          rescue NylasV2::Error => e
+            NylasV2::Logging.logger.error(e)
             raise e
           end
         end
@@ -67,7 +67,7 @@ module Nylas
       end
 
       def http_error_handler(client)
-        raise Nylas::Error, client.error
+        raise NylasV2::Error, client.error
       end
 
       def parser

--- a/lib/nylas.rb
+++ b/lib/nylas.rb
@@ -116,9 +116,9 @@ require_relative "nylas/scheduler_booking_confirmation"
 require_relative "nylas/native_authentication"
 
 require_relative "nylas/filter_attributes"
-# an SDK for interacting with the Nylas API
+# an SDK for interacting with the NylasV2 API
 # @see https://docs.nylas.com/reference
-module Nylas
+module NylasV2
   Types.registry[:account] = Types::ModelType.new(model: Account)
   Types.registry[:calendar] = Types::ModelType.new(model: Calendar)
   Types.registry[:contact] = Types::ModelType.new(model: Contact)

--- a/lib/nylas/account.rb
+++ b/lib/nylas/account.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Representation of the accounts for Account management purposes.
   # @see https://docs.nylas.com/reference#account-management
   class Account

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -36,18 +36,15 @@ module Nylas
     end
 
     def authentication_url(redirect_uri:, scopes:, response_type: "code", login_hint: nil, state: nil,
-                           provider: nil, redirect_on_error: nil)
-      params = {
-        client_id: app_id,
-        redirect_uri: redirect_uri,
-        response_type: response_type,
-        login_hint: login_hint
-      }
+                           provider: nil, redirect_on_error: nil, disable_provider_selection: nil)
+      params = { client_id: app_id, redirect_uri: redirect_uri, response_type: response_type,
+                 login_hint: login_hint }
 
       params[:state] = state if state
       params[:scopes] = scopes.join(",") if scopes
       params[:provider] = provider if provider
       params[:redirect_on_error] = redirect_on_error if redirect_on_error
+      params[:disable_provider_selection] = disable_provider_selection if disable_provider_selection
 
       "#{api_server}/oauth/authorize?#{URI.encode_www_form(params)}"
     end

--- a/lib/nylas/api.rb
+++ b/lib/nylas/api.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Methods to retrieve data from the Nylas API as Ruby objects
+module NylasV2
+  # Methods to retrieve data from the NylasV2 API as Ruby objects
   class API
     attr_accessor :client
 
@@ -11,19 +11,19 @@ module Nylas
     include Logging
 
     # @param client [HttpClient] Http Client to use for retrieving data
-    # @param app_id [String] Your application id from the Nylas Dashboard
-    # @param app_secret [String] Your application secret from the Nylas Dashboard
+    # @param app_id [String] Your application id from the NylasV2 Dashboard
+    # @param app_secret [String] Your application secret from the NylasV2 Dashboard
     # @param access_token [String] (Optional) Your users access token.
-    # @param api_server [String] (Optional) Which Nylas API Server to connect to. Only change this if
-    #                            you're using a self-hosted Nylas instance.
-    # @return [Nylas::API]
+    # @param api_server [String] (Optional) Which NylasV2 API Server to connect to. Only change this if
+    #                            you're using a self-hosted NylasV2 instance.
+    # @return [NylasV2::API]
     def initialize(client: nil, app_id: nil, app_secret: nil, access_token: nil,
                    api_server: "https://api.nylas.com")
       self.client = client || HttpClient.new(app_id: app_id, app_secret: app_secret,
                                              access_token: access_token, api_server: api_server)
     end
 
-    # @return [String] A Nylas access token for that particular user.
+    # @return [String] A NylasV2 access token for that particular user.
     def authenticate(name:, email_address:, provider:, settings:, reauth_account_id: nil, scopes: nil)
       NativeAuthentication.new(api: self).authenticate(
         name: name,
@@ -159,7 +159,7 @@ module Nylas
       @components ||= ComponentCollection.new(model: Component, api: as(client.app_secret))
     end
 
-    # Revokes access to the Nylas API for the given access token
+    # Revokes access to the NylasV2 API for the given access token
     # @return [Boolean]
     def revoke(access_token)
       response = client.as(access_token).post(path: "/oauth/revoke")

--- a/lib/nylas/application_details.rb
+++ b/lib/nylas/application_details.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Structure to represent a Nylas Application Detail object.
+module NylasV2
+  # Structure to represent a NylasV2 Application Detail object.
   # @see https://developer.nylas.com/docs/api/#get/a/client_id
   class ApplicationDetail
     include Model::Attributable

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -29,6 +29,7 @@ module Nylas
     attribute :read_only, :boolean
     attribute :metadata, :hash
     attribute :job_status_id, :string, read_only: true
+    attribute :hex_color, :string, read_only: true
 
     def read_only?
       read_only == true

--- a/lib/nylas/calendar.rb
+++ b/lib/nylas/calendar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby bindings for the Nylas Calendar API
+module NylasV2
+  # Ruby bindings for the NylasV2 Calendar API
   # @see https://docs.nylas.com/reference#calendars
   class Calendar
     include Model

--- a/lib/nylas/calendar_collection.rb
+++ b/lib/nylas/calendar_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Additional methods for some of Calendar's other functionality
   # @see https://developer.nylas.com/docs/connectivity/calendar
   class CalendarCollection < Collection
@@ -13,8 +13,8 @@ module Nylas
     # @param buffer [Integer] The amount of buffer time in minutes that you want around existing meetings
     # @param round_robin [String] Finds available meeting times in a round-robin style
     # @param event_collection_id [String] Unique identifier for a collection of events that are created
-    # @param free_busy [Array<Nylas::FreeBusy>] A list of free-busy data for users not in your organization
-    # @param open_hours [Array<Nylas::OpenHours>] Additional times email accounts are available
+    # @param free_busy [Array<NylasV2::FreeBusy>] A list of free-busy data for users not in your organization
+    # @param open_hours [Array<NylasV2::OpenHours>] Additional times email accounts are available
     # @param calendars [Array] Check account and calendar IDs for free/busy status
     # @return [Hash] The availability information; a list of time slots where all participants are available
     def availability(duration_minutes:,
@@ -55,8 +55,8 @@ module Nylas
     # @param end_time [Integer] The timestamp for the end of the event
     # @param emails [Array<Array<String>>] Emails on the same domain to check
     # @param buffer [Integer] The amount of buffer time in minutes that you want around existing meetings
-    # @param free_busy [Array<Nylas::FreeBusy>] A list of free-busy data for users not in your organization
-    # @param open_hours [Array<Nylas::OpenHours>] Additional times email accounts are available
+    # @param free_busy [Array<NylasV2::FreeBusy>] A list of free-busy data for users not in your organization
+    # @param open_hours [Array<NylasV2::OpenHours>] Additional times email accounts are available
     # @param calendars [Array] Check account and calendar IDs for free/busy status
     # @return [Hash] The availability information; a list of all possible groupings that share time slots
     def consecutive_availability(duration_minutes:,

--- a/lib/nylas/categorize.rb
+++ b/lib/nylas/categorize.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Neural Categorize object.
   # @see https://developer.nylas.com/docs/intelligence/categorizer/#categorize-message-response
   class Categorize

--- a/lib/nylas/collection.rb
+++ b/lib/nylas/collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # An enumerable for working with index and search endpoints
   class Collection
     attr_accessor :model, :api, :constraints
@@ -126,7 +126,7 @@ module Nylas
       true
     end
 
-    # Retrieves a record. Nylas doesn't support where filters on GET so this will not take into
+    # Retrieves a record. NylasV2 doesn't support where filters on GET so this will not take into
     # consideration other query constraints, such as where clauses.
     def find(id)
       constraints.accept == "application/json" ? find_model(id) : find_raw(id)

--- a/lib/nylas/component.rb
+++ b/lib/nylas/component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Component Schema.
   class Component
     include Model

--- a/lib/nylas/component_collection.rb
+++ b/lib/nylas/component_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Additional configuration for the Component CRUD API
   class ComponentCollection < Collection
     def resources_path

--- a/lib/nylas/constraints.rb
+++ b/lib/nylas/constraints.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # The constraints a particular GET request will include in their query params
   class Constraints
     attr_accessor :where, :limit, :offset, :view, :per_page, :accept

--- a/lib/nylas/contact.rb
+++ b/lib/nylas/contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # ActiveModel compliant interface for interacting with the Contacts API
   # @see https://docs.nylas.com/reference#contacts
   class Contact

--- a/lib/nylas/contact_group.rb
+++ b/lib/nylas/contact_group.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Contact Group schema
   # @see https://docs.nylas.com/reference#contactsid
   class ContactGroup

--- a/lib/nylas/current_account.rb
+++ b/lib/nylas/current_account.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of the Nylas /account API
+module NylasV2
+  # Ruby representation of the NylasV2 /account API
   # @see https://docs.nylas.com/reference#account
   class CurrentAccount
     include Model

--- a/lib/nylas/delta.rb
+++ b/lib/nylas/delta.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Ruby object to represent a single change. Used both when receiving a webhook, as well as the deltas API.
   # @see https://docs.nylas.com/reference#receiving-notifications
   # @see https://docs.nylas.com/reference#deltas

--- a/lib/nylas/deltas.rb
+++ b/lib/nylas/deltas.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Ruby object to represent a collection of changes. Used both when receiving a webhook, as well as the
   # deltas API.
   # @see https://docs.nylas.com/reference#receiving-notifications

--- a/lib/nylas/deltas_collection.rb
+++ b/lib/nylas/deltas_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Special collection for delta objects
   class DeltasCollection < Collection
     attr_accessor :deltas

--- a/lib/nylas/draft.rb
+++ b/lib/nylas/draft.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representatin of a Nylas Draft object
+module NylasV2
+  # Ruby representatin of a NylasV2 Draft object
   # @see https://docs.nylas.com/reference#drafts
   class Draft
     include Model

--- a/lib/nylas/email_address.rb
+++ b/lib/nylas/email_address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Email Address Schema
   # @see https://docs.nylas.com/reference#contactsid
   class EmailAddress

--- a/lib/nylas/errors.rb
+++ b/lib/nylas/errors.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   Error = Class.new(::StandardError)
 
   class ModelActionError < Error; end
@@ -33,7 +33,7 @@ module Nylas
   UnexpectedAccountAction = Class.new(Error)
   UnexpectedResponse = Class.new(Error)
 
-  # Base class to inflate the standard errors returned from the Nylas API
+  # Base class to inflate the standard errors returned from the NylasV2 API
   class APIError < Error
     attr_accessor :type
     attr_accessor :message

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -43,6 +43,7 @@ module Nylas
     attribute :reminder_minutes, :string
     attribute :reminder_method, :string
     attribute :job_status_id, :string, read_only: true
+    attribute :visibility, :string
 
     attr_accessor :notify_participants
 

--- a/lib/nylas/event.rb
+++ b/lib/nylas/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Event Schema.
   # @see https://docs.nylas.com/reference#events
   class Event

--- a/lib/nylas/event_collection.rb
+++ b/lib/nylas/event_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Syntactical sugar methods for some of the Event's filters
   # @see https://docs.nylas.com/reference#get-events
   class EventCollection < Collection

--- a/lib/nylas/event_conferencing.rb
+++ b/lib/nylas/event_conferencing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Event Conferencing object
   # @see https://developer.nylas.com/docs/connectivity/calendar/conference-sync-beta
   class EventConferencing

--- a/lib/nylas/event_conferencing_autocreate.rb
+++ b/lib/nylas/event_conferencing_autocreate.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the autocreate object within the Event Conferencing object
   # @see https://developer.nylas.com/docs/connectivity/calendar/conference-sync-beta
   class EventConferencingAutocreate

--- a/lib/nylas/event_conferencing_details.rb
+++ b/lib/nylas/event_conferencing_details.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the details object within the Event Conferencing object
   # @see https://developer.nylas.com/docs/connectivity/calendar/conference-sync-beta
   class EventConferencingDetails

--- a/lib/nylas/event_notification.rb
+++ b/lib/nylas/event_notification.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Event Notification object
   # @see https://developer.nylas.com/docs/connectivity/calendar/event-notifications
   class EventNotification

--- a/lib/nylas/file.rb
+++ b/lib/nylas/file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the File Schema.
   # @see https://docs.nylas.com/reference#events
   class File

--- a/lib/nylas/filter_attributes.rb
+++ b/lib/nylas/filter_attributes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Methods to check and raise error if extra attributes are present
   class FilterAttributes
     def initialize(attributes:, allowed_attributes:)

--- a/lib/nylas/folder.rb
+++ b/lib/nylas/folder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Folder Schema
   # @see https://docs.nylas.com/reference#folders
   class Folder

--- a/lib/nylas/free_busy.rb
+++ b/lib/nylas/free_busy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Query free/busy information for a calendar during a certain time period
   # @see https://docs.nylas.com/reference#calendars-free-busy
   class FreeBusy

--- a/lib/nylas/free_busy_collection.rb
+++ b/lib/nylas/free_busy_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Helper to get and build `FreeBusy` objects
   class FreeBusyCollection
     extend Forwardable

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -189,8 +189,7 @@ module Nylas
     def parse_response(response)
       return response if response.is_a?(Enumerable)
 
-      json = StringIO.new(response)
-      Yajl::Parser.new(symbolize_names: true).parse(json)
+      Yajl::Parser.new(symbolize_names: true).parse(response)
     rescue Yajl::ParseError
       raise Nylas::JsonParseError
     end

--- a/lib/nylas/http_client.rb
+++ b/lib/nylas/http_client.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   require "yajl"
   require "base64"
 
-  # Plain HTTP client that can be used to interact with the Nylas API sans any type casting.
+  # Plain HTTP client that can be used to interact with the NylasV2 API sans any type casting.
   class HttpClient
     module AuthMethod
       BEARER = 1
@@ -49,15 +49,15 @@ module Nylas
     attr_reader :app_id
     attr_reader :app_secret
 
-    # @param app_id [String] Your application id from the Nylas Dashboard
-    # @param app_secret [String] Your application secret from the Nylas Dashboard
+    # @param app_id [String] Your application id from the NylasV2 Dashboard
+    # @param app_secret [String] Your application secret from the NylasV2 Dashboard
     # @param access_token [String] (Optional) Your users access token.
-    # @param api_server [String] (Optional) Which Nylas API Server to connect to. Only change this if
-    #                            you're using a self-hosted Nylas instance.
-    # @return [Nylas::HttpClient]
+    # @param api_server [String] (Optional) Which NylasV2 API Server to connect to. Only change this if
+    #                            you're using a self-hosted NylasV2 instance.
+    # @return [NylasV2::HttpClient]
     def initialize(app_id:, app_secret:, access_token: nil, api_server: "https://api.nylas.com")
       unless api_server.include?("://")
-        raise "When overriding the Nylas API server address, you must include https://"
+        raise "When overriding the NylasV2 API server address, you must include https://"
       end
 
       @api_server = api_server
@@ -66,13 +66,13 @@ module Nylas
       @app_id = app_id
     end
 
-    # @return [Nylas::HttpClient[]
+    # @return [NylasV2::HttpClient[]
     def as(access_token)
       HttpClient.new(app_id: app_id, access_token: access_token,
                      app_secret: app_secret, api_server: api_server)
     end
 
-    # Sends a request to the Nylas API and rai
+    # Sends a request to the NylasV2 API and rai
     # @param method [Symbol] HTTP method for the API call. Either :get, :post, :delete, or :patch
     # @param path [String] (Optional, defaults to nil) - Relative path from the API Base. Preferred way to
     #                      execute arbitrary or-not-yet-SDK-ified API commands.
@@ -103,7 +103,7 @@ module Nylas
 
         begin
           response = parse_response(response) if content_type == "application/json"
-        rescue Nylas::JsonParseError
+        rescue NylasV2::JsonParseError
           handle_failed_response(result: result, response: response)
           raise
         end
@@ -178,10 +178,10 @@ module Nylas
 
     def default_headers
       @default_headers ||= {
-        "X-Nylas-API-Wrapper" => "ruby",
-        "X-Nylas-Client-Id" => @app_id,
-        "Nylas-API-Version" => SUPPORTED_API_VERSION,
-        "User-Agent" => "Nylas Ruby SDK #{Nylas::VERSION} - #{RUBY_VERSION}",
+        "X-NylasV2-API-Wrapper" => "ruby",
+        "X-NylasV2-Client-Id" => @app_id,
+        "NylasV2-API-Version" => SUPPORTED_API_VERSION,
+        "User-Agent" => "NylasV2 Ruby SDK #{NylasV2::VERSION} - #{RUBY_VERSION}",
         "Content-type" => "application/json"
       }
     end
@@ -191,7 +191,7 @@ module Nylas
 
       Yajl::Parser.new(symbolize_names: true).parse(response)
     rescue Yajl::ParseError
-      raise Nylas::JsonParseError
+      raise NylasV2::JsonParseError
     end
     inform_on :parse_response, level: :debug, also_log: { result: true }
 

--- a/lib/nylas/im_address.rb
+++ b/lib/nylas/im_address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the IM Address Schema
   # @see https://docs.nylas.com/reference#contactsid
   class IMAddress

--- a/lib/nylas/job_status.rb
+++ b/lib/nylas/job_status.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a Nylas Job Status object
+module NylasV2
+  # Ruby representation of a NylasV2 Job Status object
   # @see https://developer.nylas.com/docs/api/#tag--Job-Status
   class JobStatus
     include Model

--- a/lib/nylas/job_status_collection.rb
+++ b/lib/nylas/job_status_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Additional methods for some of Calendar's other functionality
   # @see https://developer.nylas.com/docs/connectivity/calendar
   class JobStatusCollection < Collection

--- a/lib/nylas/label.rb
+++ b/lib/nylas/label.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Label Schema
   # @see https://docs.nylas.com/reference#labels
   class Label

--- a/lib/nylas/logging.rb
+++ b/lib/nylas/logging.rb
@@ -5,7 +5,7 @@ begin
 rescue LoadError
 end
 
-module Nylas
+module NylasV2
   # Exposes a shared logger for debugging purposes
   module Logging
     def self.included(object)

--- a/lib/nylas/message.rb
+++ b/lib/nylas/message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representatin of a Nylas Message object
+module NylasV2
+  # Ruby representatin of a NylasV2 Message object
   # @see https://docs.nylas.com/reference#messages
   class Message
     include Model

--- a/lib/nylas/message_headers.rb
+++ b/lib/nylas/message_headers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Translates message headers into a Ruby object
   # @see https://docs.nylas.com/reference#section-message-views
   class MessageHeaders

--- a/lib/nylas/message_tracking.rb
+++ b/lib/nylas/message_tracking.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Message tracking features
   # @see https://docs.nylas.com/reference#message-tracking-overview
   class MessageTracking

--- a/lib/nylas/model.rb
+++ b/lib/nylas/model.rb
@@ -5,7 +5,7 @@ require_relative "model/list_attribute_definition"
 require_relative "model/attributable"
 require_relative "model/attributes"
 require_relative "model/transferable"
-module Nylas
+module NylasV2
   # Include this to define a class to represent an object returned from the API
   module Model
     attr_accessor :api

--- a/lib/nylas/model/attributable.rb
+++ b/lib/nylas/model/attributable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   module Model
     # Allows defining of typecastable attributes on a model
     module Attributable

--- a/lib/nylas/model/attribute_definition.rb
+++ b/lib/nylas/model/attribute_definition.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   module Model
     # Define a particular attribute for a given model
     class AttributeDefinition

--- a/lib/nylas/model/attributes.rb
+++ b/lib/nylas/model/attributes.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   module Model
     # Stores the actual model data to allow for type casting and clean/dirty checking
     class Attributes
@@ -17,7 +17,7 @@ module Nylas
 
       def []=(key, value)
         data[key] = cast(key, value)
-      rescue Nylas::Registry::MissingKeyError
+      rescue NylasV2::Registry::MissingKeyError
         # Don't crash when a new attribute is added
       end
 

--- a/lib/nylas/model/list_attribute_definition.rb
+++ b/lib/nylas/model/list_attribute_definition.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   module Model
     # Allows models to have an attribute which is a lists of another type of thing
     class ListAttributeDefinition

--- a/lib/nylas/model/transferable.rb
+++ b/lib/nylas/model/transferable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   module Model
     # Allows definition of attributes, which should transfer to other dependent attributes
     module Transferable

--- a/lib/nylas/native_authentication.rb
+++ b/lib/nylas/native_authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Authenticate your application using the native interface
   # @see https://docs.nylas.com/reference#native-authentication-1
   class NativeAuthentication

--- a/lib/nylas/neural.rb
+++ b/lib/nylas/neural.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Class containing methods for accessing Neural API features.
   # @see https://developer.nylas.com/docs/intelligence/
   class Neural

--- a/lib/nylas/neural_categorizer.rb
+++ b/lib/nylas/neural_categorizer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Neural Categorizer object.
   # @see https://developer.nylas.com/docs/intelligence/categorizer/#categorize-message-response
   class NeuralCategorizer < Message

--- a/lib/nylas/neural_clean_conversation.rb
+++ b/lib/nylas/neural_clean_conversation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Neural Clean Conversations object.
   # @see https://developer.nylas.com/docs/intelligence/clean-conversations/#clean-conversation-response
   class NeuralCleanConversation < Message

--- a/lib/nylas/neural_contact_link.rb
+++ b/lib/nylas/neural_contact_link.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the "Link" object in the Neural API's Signature Extraction Contact object
   # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
   class NeuralContactLink

--- a/lib/nylas/neural_contact_name.rb
+++ b/lib/nylas/neural_contact_name.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the "Name" object in the Neural API's Signature Extraction Contact object
   # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
   class NeuralContactName

--- a/lib/nylas/neural_message_options.rb
+++ b/lib/nylas/neural_message_options.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Neural Optical Character Recognition object.
   # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
   class NeuralMessageOptions

--- a/lib/nylas/neural_ocr.rb
+++ b/lib/nylas/neural_ocr.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Neural Optical Character Recognition object.
   # @see https://developer.nylas.com/docs/intelligence/optical-charecter-recognition/#ocr-response
   class NeuralOcr < File

--- a/lib/nylas/neural_sentiment_analysis.rb
+++ b/lib/nylas/neural_sentiment_analysis.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Neural Sentiment Analysis object.
   # @see https://developer.nylas.com/docs/intelligence/sentiment-analysis/#sentiment-analysis-response-message
   class NeuralSentimentAnalysis

--- a/lib/nylas/neural_signature_contact.rb
+++ b/lib/nylas/neural_signature_contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Neural API's Signature Extraction Contact object
   # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#parse-signature-response
   class NeuralSignatureContact
@@ -13,7 +13,7 @@ module Nylas
 
     attr_accessor :api
 
-    # Creates a Nylas contact object compatible with the contact endpoints.
+    # Creates a NylasV2 contact object compatible with the contact endpoints.
     # Please note if multiple names or multiple job titles were parsed only
     # the first set are used.
     def to_contact_object

--- a/lib/nylas/neural_signature_extraction.rb
+++ b/lib/nylas/neural_signature_extraction.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent a the Signature Extraction Schema.
   # @see https://developer.nylas.com/docs/intelligence/signature-extraction/#signature-feedback-response
   class NeuralSignatureExtraction < Message

--- a/lib/nylas/new_message.rb
+++ b/lib/nylas/new_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Data structure for sending a message via the Nylas API
+module NylasV2
+  # Data structure for sending a message via the NylasV2 API
   class NewMessage
     include Model
     self.creatable = false

--- a/lib/nylas/nylas_date.rb
+++ b/lib/nylas/nylas_date.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Structure to represent Nylas's more complex Date Schema
+module NylasV2
+  # Structure to represent NylasV2's more complex Date Schema
   # @see https://docs.nylas.com/reference#contactsid
   class NylasDate
     extend Forwardable

--- a/lib/nylas/open_hours.rb
+++ b/lib/nylas/open_hours.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Additional times email accounts are available
   # @see https://developer.nylas.com/docs/api/#post/calendars/availability
   class OpenHours

--- a/lib/nylas/outbox.rb
+++ b/lib/nylas/outbox.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Methods for Outbox functionality
   # @see https://developer.nylas.com/docs/api/#tag--Outbox
   class Outbox

--- a/lib/nylas/outbox_job_status.rb
+++ b/lib/nylas/outbox_job_status.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a Nylas Outbox Job Status object
+module NylasV2
+  # Ruby representation of a NylasV2 Outbox Job Status object
   # @see https://developer.nylas.com/docs/api/#post/v2/outbox
   class OutboxJobStatus < JobStatus
     include Model

--- a/lib/nylas/outbox_message.rb
+++ b/lib/nylas/outbox_message.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a Nylas Outbox Message object
+module NylasV2
+  # Ruby representation of a NylasV2 Outbox Message object
   # @see https://developer.nylas.com/docs/api/#post/v2/outbox
   class OutboxMessage < Draft
     include Model

--- a/lib/nylas/participant.rb
+++ b/lib/nylas/participant.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Participant
   class Participant
     include Model::Attributable

--- a/lib/nylas/phone_number.rb
+++ b/lib/nylas/phone_number.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Phone Number Schema
   # @see https://docs.nylas.com/reference#contactsid
   class PhoneNumber

--- a/lib/nylas/physical_address.rb
+++ b/lib/nylas/physical_address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Physical Address schema
   # @see https://docs.nylas.com/reference#contactsid
   class PhysicalAddress

--- a/lib/nylas/raw_message.rb
+++ b/lib/nylas/raw_message.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Allows sending of email with nylas from an rfc822 compatible string
   class RawMessage
     attr_accessor :api, :mime_compatible_string

--- a/lib/nylas/recurrence.rb
+++ b/lib/nylas/recurrence.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Representation of a Recurrence object
   # @see https://docs.nylas.com/reference#section-recurrence
   class Recurrence

--- a/lib/nylas/registry.rb
+++ b/lib/nylas/registry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Used to create a hash-like structure which defaults to raising an exception in the event the key to
   # retrieve does not exist.
   class Registry

--- a/lib/nylas/room_resource.rb
+++ b/lib/nylas/room_resource.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a Nylas Room Resource object
+module NylasV2
+  # Ruby representation of a NylasV2 Room Resource object
   # @see https://developer.nylas.com/docs/api/#tag--Room-Resources
   class RoomResource
     include Model

--- a/lib/nylas/rsvp.rb
+++ b/lib/nylas/rsvp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Allows RSVPing to a particular event
   # @see https://docs.nylas.com/reference#rsvping-to-invitations
   class Rsvp

--- a/lib/nylas/scheduler.rb
+++ b/lib/nylas/scheduler.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a the Nylas Scheduler API
+module NylasV2
+  # Ruby representation of a the NylasV2 Scheduler API
   # @see https://developer.nylas.com/docs/api/scheduler/#overview
   class Scheduler
     include Model

--- a/lib/nylas/scheduler_booking_confirmation.rb
+++ b/lib/nylas/scheduler_booking_confirmation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the booking response returned from the Scheduler API
   class SchedulerBookingConfirmation
     include Model::Attributable

--- a/lib/nylas/scheduler_booking_request.rb
+++ b/lib/nylas/scheduler_booking_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the booking request used for the Scheduler API
   class SchedulerBookingRequest
     include Model::Attributable

--- a/lib/nylas/scheduler_collection.rb
+++ b/lib/nylas/scheduler_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Additional methods for some of Scheduler's other functionality
   # @see https://developer.nylas.com/docs/api/scheduler#overview
   class SchedulerCollection < Collection

--- a/lib/nylas/scheduler_config.rb
+++ b/lib/nylas/scheduler_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Configuration settings for a Scheduler page
   # @see https://developer.nylas.com/docs/api/scheduler
   class SchedulerConfig

--- a/lib/nylas/scheduler_time_slot.rb
+++ b/lib/nylas/scheduler_time_slot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the time slot object from the Scheduler API
   class SchedulerTimeSlot
     include Model::Attributable

--- a/lib/nylas/search_collection.rb
+++ b/lib/nylas/search_collection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Ensures our search requests hit the right path
   class SearchCollection < Collection
     def resources_path

--- a/lib/nylas/send_grid_verified_status.rb
+++ b/lib/nylas/send_grid_verified_status.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of a Nylas Send Grid verified status object
+module NylasV2
+  # Ruby representation of a NylasV2 Send Grid verified status object
   # @see https://docs.nylas.com/reference#drafts
   class SendGridVerifiedStatus
     include Model::Attributable

--- a/lib/nylas/thread.rb
+++ b/lib/nylas/thread.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Ruby representation of the Nylas /threads API
+module NylasV2
+  # Ruby representation of the NylasV2 /threads API
   # @see https://docs.nylas.com/reference#threads
   class Thread
     include Model

--- a/lib/nylas/time_slot.rb
+++ b/lib/nylas/time_slot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Query free/busy information for a calendar during a certain time period
   # @see https://docs.nylas.com/reference#calendars-free-busy
   class TimeSlot

--- a/lib/nylas/time_slot_capacity.rb
+++ b/lib/nylas/time_slot_capacity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Capacity values for a timeslot
   # @see https://docs.nylas.com/reference#calendars-free-busy
   class TimeSlotCapacity

--- a/lib/nylas/timespan.rb
+++ b/lib/nylas/timespan.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Structure to represent a Nylas Timespan.
+module NylasV2
+  # Structure to represent a NylasV2 Timespan.
   # @see https://docs.nylas.com/reference#section-timespan
   class Timespan
     extend Forwardable

--- a/lib/nylas/token_info.rb
+++ b/lib/nylas/token_info.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Nylas
-  # Structure to represent information about a Nylas access token.
+module NylasV2
+  # Structure to represent information about a NylasV2 access token.
   # @see https://developer.nylas.com/docs/api/#post/a/client_id/accounts/id/token-info
   class TokenInfo
     include Model::Attributable

--- a/lib/nylas/types.rb
+++ b/lib/nylas/types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Collection of attribute types
   module Types
     def self.registry

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.12.1"
+  VERSION = "5.13.0"
 end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Nylas
-  VERSION = "5.13.0"
+  VERSION = "5.14.0"
 end

--- a/lib/nylas/version.rb
+++ b/lib/nylas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   VERSION = "5.14.0"
 end

--- a/lib/nylas/web_page.rb
+++ b/lib/nylas/web_page.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   # Structure to represent the Web Page Schema
   # @see https://docs.nylas.com/reference#contactsid
   class WebPage

--- a/lib/nylas/webhook.rb
+++ b/lib/nylas/webhook.rb
@@ -36,7 +36,7 @@ module WebhookTrigger
   JOB_FAILED = "job.failed"
 end
 
-module Nylas
+module NylasV2
   # Represents a webhook attached to your application.
   # @see https://docs.nylas.com/reference#webhooks
   class Webhook

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Nylas
+  require "tzinfo"
+
   # Structure to represent all the Nylas time types.
   # @see https://docs.nylas.com/reference#section-time
   class When
@@ -19,10 +21,15 @@ module Nylas
 
     # when object == 'time'
     attribute :time, :unix_timestamp
+    # Timezone must be set to a valid IANA database timezone name
+    attribute :timezone, :string
 
     # when object == 'timespan'
     attribute :start_time, :unix_timestamp
     attribute :end_time, :unix_timestamp
+    # Both timezone fields must be set to a valid IANA database timezone name
+    attribute :start_timezone, :string
+    attribute :end_timezone, :string
 
     def_delegators :range, :cover?
 
@@ -43,6 +50,26 @@ module Nylas
       when "time"
         Range.new(time, time)
       end
+    end
+
+    # Validates the When object
+    # @return [Boolean] True if the When is valid
+    # @raise [ArgumentError] If any of the timezone fields are not valid IANA database names
+    def valid?
+      validate_timezone(timezone) if timezone
+      validate_timezone(start_timezone) if start_timezone
+      validate_timezone(end_timezone) if end_timezone
+
+      true
+    end
+
+    private
+
+    def validate_timezone(timezone_var)
+      return if TZInfo::Timezone.all_identifiers.include?(timezone_var)
+
+      raise ArgumentError,
+            format("The timezone provided (%s) is not a valid IANA timezone database name", timezone_var)
     end
   end
 end

--- a/lib/nylas/when.rb
+++ b/lib/nylas/when.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-module Nylas
+module NylasV2
   require "tzinfo"
 
-  # Structure to represent all the Nylas time types.
+  # Structure to represent all the NylasV2 time types.
   # @see https://docs.nylas.com/reference#section-time
   class When
     extend Forwardable

--- a/nylas-streaming.gemspec
+++ b/nylas-streaming.gemspec
@@ -4,8 +4,8 @@ require "./gem_config"
 
 Gem::Specification.new do |gem|
   GemConfig.apply(gem, "nylas-streaming")
-  gem.summary = %(Gem for interacting with the Nylas Deltas Streaming API)
-  gem.description = %(Gem for interacting with the Nylas Deltas Streaming API.)
+  gem.summary = %(Gem for interacting with the NylasV2 Deltas Streaming API)
+  gem.description = %(Gem for interacting with the NylasV2 Deltas Streaming API.)
 
   gem.add_runtime_dependency "em-http-request", "~> 1.1", ">= 1.1.3"
   gem.add_runtime_dependency "nylas", "~> 4.0"

--- a/nylas.gemspec
+++ b/nylas.gemspec
@@ -4,8 +4,8 @@ require "./gem_config"
 
 Gem::Specification.new do |gem|
   GemConfig.apply(gem, "nylas")
-  gem.summary = %(Gem for interacting with the Nylas API)
-  gem.description = %(Gem for interacting with the Nylas API.)
+  gem.summary = %(Gem for interacting with the NylasV2 API)
+  gem.description = %(Gem for interacting with the NylasV2 API.)
   gem.add_runtime_dependency "rest-client", ">= 2.0", "< 3.0"
   gem.add_runtime_dependency "yajl-ruby", "~> 1.2", ">= 1.2.1"
 end

--- a/spec/nylas/account_spec.rb
+++ b/spec/nylas/account_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Account do
+describe NylasV2::Account do
   it "is filterable" do
     expect(described_class).to be_filterable
   end
@@ -40,7 +40,7 @@ describe Nylas::Account do
   end
 
   it "can update metadata" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("NylasV2::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     account.metadata = {
@@ -49,7 +49,7 @@ describe Nylas::Account do
     account.save
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :put,
       path: "/a/app-987/accounts/acc-1234",
       payload: JSON.dump(
@@ -62,13 +62,13 @@ describe Nylas::Account do
   end
 
   it "can be downgraded" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("NylasV2::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.downgrade).to be_truthy
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/downgrade",
       payload: nil,
@@ -77,13 +77,13 @@ describe Nylas::Account do
   end
 
   it "can be upgraded" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("NylasV2::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.upgrade).to be_truthy
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/upgrade",
       payload: nil,
@@ -92,14 +92,14 @@ describe Nylas::Account do
   end
 
   it "can revoke all tokens" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("NylasV2::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
     access_token = "some_access_token"
 
     expect(account.revoke_all(keep_access_token: access_token)).to be_truthy
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/revoke-all",
       payload: be_json("keep_access_token" => access_token),
@@ -108,13 +108,13 @@ describe Nylas::Account do
   end
 
   it "can be destroyed" do
-    api = instance_double("Nylas::API", execute: { success: true }, app_id: "app-987")
+    api = instance_double("NylasV2::API", execute: { success: true }, app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
 
     expect(account.destroy).to be_truthy
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :delete,
       path: "/a/app-987/accounts/acc-1234",
       payload: nil,
@@ -123,7 +123,7 @@ describe Nylas::Account do
   end
 
   it "can return token information" do
-    api = instance_double("Nylas::API", app_id: "app-987")
+    api = instance_double("NylasV2::API", app_id: "app-987")
     account = described_class.from_json('{ "id": "acc-1234" }', api: api)
     token_info_response = {
       scopes: "email.send,email.modify,calendar",
@@ -136,7 +136,7 @@ describe Nylas::Account do
     token_info = account.token_info("test-token")
 
     expect(api).to have_received(:execute).with(
-      auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+      auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
       method: :post,
       path: "/a/app-987/accounts/acc-1234/token-info",
       payload: be_json("access_token" => "test-token"),

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -82,7 +82,8 @@ describe Nylas::API do
           login_hint: "email@example.com",
           state: "some-state",
           provider: "gmail",
-          redirect_on_error: true
+          redirect_on_error: true,
+          disable_provider_selection: true
         )
 
         expected_url = "https://api.nylas.com/oauth/authorize"\
@@ -93,7 +94,8 @@ describe Nylas::API do
         "&state=some-state"\
         "&scopes=email%2Ccalendar"\
         "&provider=gmail"\
-        "&redirect_on_error=true"
+        "&redirect_on_error=true"\
+        "&disable_provider_selection=true"
         expect(hosted_auth_url).to eq expected_url
       end
     end

--- a/spec/nylas/api_spec.rb
+++ b/spec/nylas/api_spec.rb
@@ -4,10 +4,10 @@ require "spec_helper"
 
 # This spec is the only one that should have any webmock stuff going on, everything else should use the
 # FakeAPI to see what requests were made and what they included.
-describe Nylas::API do
+describe NylasV2::API do
   describe "#exchange_code_for_token" do
     it "retrieves oauth token with code" do
-      client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
+      client = NylasV2::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
       data = {
         "client_id" => "fake-app",
         "client_secret" => "fake-secret",
@@ -28,7 +28,7 @@ describe Nylas::API do
     end
 
     it "retrieves full response from the server" do
-      client = Nylas::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
+      client = NylasV2::HttpClient.new(app_id: "fake-app", app_secret: "fake-secret")
       data = {
         "client_id" => "fake-app",
         "client_secret" => "fake-secret",
@@ -136,19 +136,19 @@ describe Nylas::API do
   end
 
   describe "#contact_groups" do
-    it "returns Nylas::Collection for contact groups" do
-      client = instance_double("Nylas::HttpClient")
+    it "returns NylasV2::Collection for contact groups" do
+      client = instance_double("NylasV2::HttpClient")
       api = described_class.new(client: client)
 
       result = api.contact_groups
 
-      expect(result).to be_a(Nylas::Collection)
+      expect(result).to be_a(NylasV2::Collection)
     end
   end
 
   describe "#current_account" do
     it "retrieves the account for the current OAuth Access Token" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real",
+      client = NylasV2::HttpClient.new(app_id: "not-real", app_secret: "also-not-real",
                                      access_token: "seriously-unreal")
       allow(client).to receive(:execute).with(method: :get, path: "/account").and_return(id: 1234)
       api = described_class.new(client: client)
@@ -156,26 +156,26 @@ describe Nylas::API do
     end
 
     it "raises an exception if there is not an access token set" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      client = NylasV2::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
       allow(client).to receive(:execute).with(method: :get, path: "/account").and_return(id: 1234)
       api = described_class.new(client: client)
-      expect { api.current_account.id }.to raise_error Nylas::NoAuthToken,
+      expect { api.current_account.id }.to raise_error NylasV2::NoAuthToken,
                                                        "No access token was provided and the " \
                                                        "current_account method requires one"
     end
 
-    it "sets X-Nylas-Client-Id header" do
-      client = Nylas::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
-      expect(client.default_headers).to include("X-Nylas-Client-Id" => "not-real")
+    it "sets X-NylasV2-Client-Id header" do
+      client = NylasV2::HttpClient.new(app_id: "not-real", app_secret: "also-not-real")
+      expect(client.default_headers).to include("X-NylasV2-Client-Id" => "not-real")
     end
   end
 
   describe "#free_busy" do
-    it "returns `Nylas::FreeBusyCollection` for free busy details" do
+    it "returns `NylasV2::FreeBusyCollection` for free busy details" do
       emails = ["test@example.com", "anothertest@example.com"]
       start_time = 1_609_439_400
       end_time = 1_640_975_400
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
@@ -211,7 +211,7 @@ describe Nylas::API do
         end_time: Time.at(end_time)
       )
 
-      expect(result).to be_a(Nylas::FreeBusyCollection)
+      expect(result).to be_a(NylasV2::FreeBusyCollection)
       free_busy = result.last
       expect(free_busy.object).to eq("free_busy")
       expect(free_busy.email).to eq("test@example.com")
@@ -225,7 +225,7 @@ describe Nylas::API do
 
   describe "application details" do
     it "gets the application details" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real"
       )
@@ -244,7 +244,7 @@ describe Nylas::API do
 
       app_details = api.application_details
 
-      expect(app_details).to be_a(Nylas::ApplicationDetail)
+      expect(app_details).to be_a(NylasV2::ApplicationDetail)
       expect(app_details.application_name).to eq("My New App Name")
       expect(app_details.icon_url).to eq("http://localhost/icon.png")
       expect(app_details.redirect_uris).to eq(%w[http://localhost/callback])
@@ -256,11 +256,11 @@ describe Nylas::API do
         icon_url: "http://localhost/updated_icon.png",
         redirect_uris: %w[http://localhost/callback http://localhost/updated]
       }
-      app_details = Nylas::ApplicationDetail.new
+      app_details = NylasV2::ApplicationDetail.new
       app_details.application_name = "Updated App Name"
       app_details.icon_url = "http://localhost/updated_icon.png"
       app_details.redirect_uris = %w[http://localhost/callback http://localhost/updated]
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real"
       )
@@ -274,7 +274,7 @@ describe Nylas::API do
 
       updated_app_details = api.update_application_details(app_details)
 
-      expect(updated_app_details).to be_a(Nylas::ApplicationDetail)
+      expect(updated_app_details).to be_a(NylasV2::ApplicationDetail)
     end
   end
 

--- a/spec/nylas/calendar_collection_spec.rb
+++ b/spec/nylas/calendar_collection_spec.rb
@@ -2,13 +2,13 @@
 
 require "spec_helper"
 
-describe Nylas::CalendarCollection do
+describe NylasV2::CalendarCollection do
   describe "availability" do
     it "makes a request to get single availability" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
 
-      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
-      free_busy = Nylas::FreeBusy.new(
+      calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
+      free_busy = NylasV2::FreeBusy.new(
         email: "swag@nylas.com",
         time_slots: [
           {
@@ -19,7 +19,7 @@ describe Nylas::CalendarCollection do
           }
         ]
       )
-      open_hours = Nylas::OpenHours.new(
+      open_hours = NylasV2::OpenHours.new(
         emails: ["swag@nylas.com"],
         days: [0],
         timezone: "America/Chicago",
@@ -80,8 +80,8 @@ describe Nylas::CalendarCollection do
     end
 
     it "optional params are omitted when getting single availability" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
 
       calendar_collection.availability(
         duration_minutes: 30,
@@ -108,10 +108,10 @@ describe Nylas::CalendarCollection do
     end
 
     it "makes a request to get multiple availability" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
 
-      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
-      free_busy = Nylas::FreeBusy.new(
+      calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
+      free_busy = NylasV2::FreeBusy.new(
         email: "swag@nylas.com",
         time_slots: [
           {
@@ -122,7 +122,7 @@ describe Nylas::CalendarCollection do
           }
         ]
       )
-      open_hours = Nylas::OpenHours.new(
+      open_hours = NylasV2::OpenHours.new(
         emails: %w[one@example.com two@example.com three@example.com swag@nylas.com],
         days: [0],
         timezone: "America/Chicago",
@@ -179,8 +179,8 @@ describe Nylas::CalendarCollection do
     end
 
     it "optional params are omitted when getting multiple availability" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
 
       calendar_collection.consecutive_availability(
         duration_minutes: 30,
@@ -209,10 +209,10 @@ describe Nylas::CalendarCollection do
 
   describe "verification" do
     it "throws an error if an email does not exist in open hours" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
 
-      calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
-      free_busy = Nylas::FreeBusy.new(
+      calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
+      free_busy = NylasV2::FreeBusy.new(
         email: "one@example.com",
         time_slots: [
           {
@@ -223,7 +223,7 @@ describe Nylas::CalendarCollection do
           }
         ]
       )
-      open_hours = Nylas::OpenHours.new(
+      open_hours = NylasV2::OpenHours.new(
         emails: %w[one@example.com two@example.com three@example.com swag@nylas.com],
         days: [0],
         timezone: "America/Chicago",
@@ -248,8 +248,8 @@ describe Nylas::CalendarCollection do
   end
 
   it "throws an error if at least one of 'emails' or 'calendars' is not provided" do
-    api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-    calendar_collection = described_class.new(model: Nylas::Calendar, api: api)
+    api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+    calendar_collection = described_class.new(model: NylasV2::Calendar, api: api)
 
     expect do
       calendar_collection.consecutive_availability(

--- a/spec/nylas/calendar_spec.rb
+++ b/spec/nylas/calendar_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+describe Nylas::Calendar do
+  describe "JSONs" do
+    let(:calendar) do
+      api = instance_double(Nylas::API)
+      data = {
+        id: "cal-8766",
+        object: "calendar",
+        account_id: "acc-1234",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        job_status_id: "job-1234",
+        metadata: {
+          lang: "ruby"
+        },
+        hex_color: "#0099EE",
+        is_primary: false,
+        read_only: true
+      }
+
+      described_class.from_json(JSON.dump(data), api: api)
+    end
+
+    it "Deserializes all the attributes into Ruby objects" do
+      expect(calendar.id).to eql "cal-8766"
+      expect(calendar.object).to eql "calendar"
+      expect(calendar.account_id).to eql "acc-1234"
+      expect(calendar.name).to eql "My Calendar"
+      expect(calendar.description).to eql "Ruby Test Calendar"
+      expect(calendar.location).to eql "Ruby SDK"
+      expect(calendar.timezone).to eql "America/New_York"
+      expect(calendar.job_status_id).to eql "job-1234"
+      expect(calendar.metadata).to eq(lang: "ruby")
+      expect(calendar.hex_color).to eql "#0099EE"
+      expect(calendar.is_primary).to be false
+      expect(calendar.read_only).to be true
+    end
+
+    it "Serializes all non-read only attributes for the API" do
+      expected_json = {
+        id: "cal-8766",
+        account_id: "acc-1234",
+        object: "calendar",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        is_primary: false,
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        read_only: true,
+        metadata: {
+          lang: "ruby"
+        }
+      }.to_json
+
+      json = calendar.attributes.serialize_for_api
+
+      expect(json).to eql expected_json
+    end
+  end
+
+  describe "read on" do
+    it "Serializes all the attributes into Ruby objects" do
+      api = instance_double(Nylas::API)
+      data = {
+        id: "cal-8766",
+        object: "calendar",
+        account_id: "acc-1234",
+        name: "My Calendar",
+        description: "Ruby Test Calendar",
+        location: "Ruby SDK",
+        timezone: "America/New_York",
+        job_status_id: "job-1234",
+        metadata: {
+          lang: "ruby"
+        },
+        hex_color: "#0099EE",
+        is_primary: false,
+        read_only: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar.id).to eql "cal-8766"
+      expect(calendar.object).to eql "calendar"
+      expect(calendar.account_id).to eql "acc-1234"
+      expect(calendar.name).to eql "My Calendar"
+      expect(calendar.description).to eql "Ruby Test Calendar"
+      expect(calendar.location).to eql "Ruby SDK"
+      expect(calendar.timezone).to eql "America/New_York"
+      expect(calendar.job_status_id).to eql "job-1234"
+      expect(calendar.metadata).to eq(lang: "ruby")
+      expect(calendar.hex_color).to eql "#0099EE"
+      expect(calendar.is_primary).to be false
+      expect(calendar.read_only).to be true
+    end
+  end
+
+  describe "#read_only?" do
+    it "returns true when read_only attribute from API return true" do
+      api = instance_double(Nylas::API)
+      data = {
+        read_only: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).to be_read_only
+    end
+
+    it "returns false when read_only attribute from API return false" do
+      api = instance_double(Nylas::API)
+      data = {
+        read_only: false
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).not_to be_read_only
+    end
+  end
+
+  describe "#primary?" do
+    it "returns true when is_primary attribute from API return true" do
+      api = instance_double(Nylas::API)
+      data = {
+        is_primary: true
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).to be_primary
+    end
+
+    it "returns false when is_primary attribute from API return false" do
+      api = instance_double(Nylas::API)
+      data = {
+        is_primary: false
+      }
+
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      expect(calendar).not_to be_primary
+    end
+  end
+
+  describe "#events" do
+    it "sets the constraints properly for getting child events" do
+      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      events = Nylas::EventCollection.new(model: Nylas::Event, api: api)
+      allow(api).to receive(:events).and_return(events)
+      data = {
+        id: "cal-123"
+      }
+      calendar = described_class.from_json(JSON.dump(data), api: api)
+
+      event_collection = calendar.events
+
+      expect(event_collection).to be_a Nylas::EventCollection
+
+      event_collection.execute
+
+      expect(api).to have_received(:execute).with(
+        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        headers: {},
+        method: :get,
+        path: "/events",
+        query: { calendar_id: "cal-123", limit: 100, offset: 0 }
+      )
+    end
+  end
+end

--- a/spec/nylas/calendar_spec.rb
+++ b/spec/nylas/calendar_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-describe Nylas::Calendar do
+describe NylasV2::Calendar do
   describe "JSONs" do
     let(:calendar) do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "cal-8766",
         object: "calendar",
@@ -63,7 +63,7 @@ describe Nylas::Calendar do
 
   describe "read on" do
     it "Serializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "cal-8766",
         object: "calendar",
@@ -100,7 +100,7 @@ describe Nylas::Calendar do
 
   describe "#read_only?" do
     it "returns true when read_only attribute from API return true" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         read_only: true
       }
@@ -111,7 +111,7 @@ describe Nylas::Calendar do
     end
 
     it "returns false when read_only attribute from API return false" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         read_only: false
       }
@@ -124,7 +124,7 @@ describe Nylas::Calendar do
 
   describe "#primary?" do
     it "returns true when is_primary attribute from API return true" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         is_primary: true
       }
@@ -135,7 +135,7 @@ describe Nylas::Calendar do
     end
 
     it "returns false when is_primary attribute from API return false" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         is_primary: false
       }
@@ -148,8 +148,8 @@ describe Nylas::Calendar do
 
   describe "#events" do
     it "sets the constraints properly for getting child events" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      events = Nylas::EventCollection.new(model: Nylas::Event, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      events = NylasV2::EventCollection.new(model: NylasV2::Event, api: api)
       allow(api).to receive(:events).and_return(events)
       data = {
         id: "cal-123"
@@ -158,12 +158,12 @@ describe Nylas::Calendar do
 
       event_collection = calendar.events
 
-      expect(event_collection).to be_a Nylas::EventCollection
+      expect(event_collection).to be_a NylasV2::EventCollection
 
       event_collection.execute
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         headers: {},
         method: :get,
         path: "/events",

--- a/spec/nylas/collection_spec.rb
+++ b/spec/nylas/collection_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Collection do
+describe NylasV2::Collection do
   def example_instance_json
     '{ "id": "1234" }'
   end
@@ -17,7 +17,7 @@ describe Nylas::Collection do
     it "Returns an enumerable for a single page of results, filtered by `offset` and `limit` and `where`" do
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { limit: 100, offset: 0 },
@@ -34,7 +34,7 @@ describe Nylas::Collection do
     it "allows you to use a block directly" do
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { limit: 100, offset: 0 },
@@ -58,7 +58,7 @@ describe Nylas::Collection do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { limit: 100, offset: 0 },
@@ -67,7 +67,7 @@ describe Nylas::Collection do
 
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { limit: 100, offset: 100 },
@@ -82,7 +82,7 @@ describe Nylas::Collection do
     it "retrieves a single object, without filtering based upon `where` clauses earlier in the chain" do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -104,7 +104,7 @@ describe Nylas::Collection do
       expect(instance.id).to eql "1234"
       expect(instance.api).to eq(api)
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: { view: "expanded" },
@@ -121,7 +121,7 @@ describe Nylas::Collection do
       expect(instance.id).to eql "1234"
       expect(instance.api).to eq(api)
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -139,7 +139,7 @@ describe Nylas::Collection do
         ]
       )
       allow(api).to receive(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/collection/1234",
         query: {},
@@ -155,7 +155,7 @@ describe Nylas::Collection do
   describe "#where" do
     it "raises a NotImplementedError stating the model is not searchable when the model is not searchable" do
       collection = described_class.new(model: NonFilterableModel, api: api)
-      expect { collection.where(id: "1234") }.to raise_error(Nylas::ModelNotFilterableError)
+      expect { collection.where(id: "1234") }.to raise_error(NylasV2::ModelNotFilterableError)
     end
   end
 
@@ -163,7 +163,7 @@ describe Nylas::Collection do
     it "sends the data to the appropriate endpoint using a post"
     it "Raises a not implemented error if the model is not creatable" do
       collection = described_class.new(model: NotCreatableModel, api: api)
-      expect { collection.create(string: "1234") }.to raise_error(Nylas::ModelNotCreatableError)
+      expect { collection.create(string: "1234") }.to raise_error(NylasV2::ModelNotCreatableError)
     end
   end
 
@@ -173,7 +173,7 @@ describe Nylas::Collection do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { limit: 100, offset: 0, view: "count" },
@@ -187,7 +187,7 @@ describe Nylas::Collection do
       collection = described_class.new(model: FullModel, api: api)
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :get,
           path: "/collection",
           query: { id: "1234", limit: 100, offset: 0, view: "count" },
@@ -203,7 +203,7 @@ describe Nylas::Collection do
         collection = described_class.new(model: FullModel, api: api)
         allow(api).to receive(:execute)
           .with(
-            auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+            auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
             method: :get,
             path: "/collection",
             query: { limit: 100, offset: 0 },
@@ -217,26 +217,26 @@ describe Nylas::Collection do
 
   describe "HTTP errors" do
     http_codes_errors = {
-      400 => Nylas::InvalidRequest,
-      401 => Nylas::UnauthorizedRequest,
-      402 => Nylas::MessageRejected,
-      403 => Nylas::AccessDenied,
-      404 => Nylas::ResourceNotFound,
-      405 => Nylas::MethodNotAllowed,
-      410 => Nylas::ResourceRemoved,
-      418 => Nylas::TeapotError,
-      422 => Nylas::MailProviderError,
-      429 => Nylas::SendingQuotaExceeded,
-      500 => Nylas::InternalError,
-      501 => Nylas::EndpointNotYetImplemented,
-      502 => Nylas::BadGateway,
-      503 => Nylas::ServiceUnavailable,
-      504 => Nylas::RequestTimedOut
+      400 => NylasV2::InvalidRequest,
+      401 => NylasV2::UnauthorizedRequest,
+      402 => NylasV2::MessageRejected,
+      403 => NylasV2::AccessDenied,
+      404 => NylasV2::ResourceNotFound,
+      405 => NylasV2::MethodNotAllowed,
+      410 => NylasV2::ResourceRemoved,
+      418 => NylasV2::TeapotError,
+      422 => NylasV2::MailProviderError,
+      429 => NylasV2::SendingQuotaExceeded,
+      500 => NylasV2::InternalError,
+      501 => NylasV2::EndpointNotYetImplemented,
+      502 => NylasV2::BadGateway,
+      503 => NylasV2::ServiceUnavailable,
+      504 => NylasV2::RequestTimedOut
     }
 
     http_codes_errors.each do |code, error|
       it "raises error if API returns #{error} with #{code}" do
-        api = Nylas::API.new
+        api = NylasV2::API.new
         model = instance_double("Model")
         allow(model).to receive(:searchable?).and_return(true)
         allow(model).to receive(:resources_path)

--- a/spec/nylas/component_spec.rb
+++ b/spec/nylas/component_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-describe Nylas::Component do
+describe NylasV2::Component do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: "abc-123",
         account_id: "account-123",
@@ -45,12 +45,12 @@ describe Nylas::Component do
 
   describe "saving" do
     it "POST with no ID set" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         account_id: "account-123",
         name: "test-component",
@@ -71,7 +71,7 @@ describe Nylas::Component do
       component.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/component/not-real",
         payload: JSON.dump(
@@ -90,12 +90,12 @@ describe Nylas::Component do
     end
 
     it "PUT with ID set" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: "abc-123",
         account_id: "account-123",
@@ -117,7 +117,7 @@ describe Nylas::Component do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/component/not-real/abc-123",
         payload: JSON.dump(

--- a/spec/nylas/contact_group_spec.rb
+++ b/spec/nylas/contact_group_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::ContactGroup do
+describe NylasV2::ContactGroup do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
   end
@@ -31,7 +31,7 @@ describe Nylas::ContactGroup do
 
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "group-id",
         account_id: "account-id",

--- a/spec/nylas/contact_spec.rb
+++ b/spec/nylas/contact_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Contact do
+describe NylasV2::Contact do
   let(:full_json) do
     '{ "id": "1234", "object": "contact", "account_id": "12345", ' \
       '"given_name":"given", "middle_name": "middle", "surname": "surname", ' \
@@ -32,7 +32,7 @@ describe Nylas::Contact do
       contact.update(given_name: "Given", birthday: "2017-01-01",
                      emails: [
                        { type: "work", email: "given@other-job.example.com" },
-                       Nylas::EmailAddress.new(type: "home", email: "given@other-home.example.com")
+                       NylasV2::EmailAddress.new(type: "home", email: "given@other-home.example.com")
                      ])
       expect(contact.given_name).to eql "Given"
 

--- a/spec/nylas/current_account_spec.rb
+++ b/spec/nylas/current_account_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::CurrentAccount do
+describe NylasV2::CurrentAccount do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
   end

--- a/spec/nylas/delta_spec.rb
+++ b/spec/nylas/delta_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Delta do
+describe NylasV2::Delta do
   it "initialize data" do
     data = {
       object: "message",
@@ -62,7 +62,7 @@ describe Nylas::Delta do
 
       delta = described_class.new(**data)
 
-      expect(delta.model).to be_a(Nylas::Message)
+      expect(delta.model).to be_a(NylasV2::Message)
     end
 
     it "returns `nil` if `object` is nil" do

--- a/spec/nylas/deltas_collection_spec.rb
+++ b/spec/nylas/deltas_collection_spec.rb
@@ -2,13 +2,13 @@
 
 require "spec_helper"
 
-describe Nylas::DeltasCollection do
+describe NylasV2::DeltasCollection do
   describe "#find_each" do
     it "supports iterating until the responses are empty" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           path: "/delta",
           method: :get,
           query: { cursor: "1", limit: 100, offset: 0 },
@@ -16,7 +16,7 @@ describe Nylas::DeltasCollection do
         ).and_return(deltas: [{ object: "draft" }], cursor_start: "1", cursor_end: "2")
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           path: "/delta",
           method: :get,
           query: { cursor: "2", limit: 100, offset: 0 },
@@ -24,7 +24,7 @@ describe Nylas::DeltasCollection do
         ).and_return(deltas: [{ object: "message" }], cursor_start: "2", cursor_end: "3")
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           path: "/delta",
           method: :get,
           query: { cursor: "3", limit: 100, offset: 0 },
@@ -42,14 +42,14 @@ describe Nylas::DeltasCollection do
 
   describe "#latest" do
     it "retrieves the results for the cursor that comes from the latest_cursor end point" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute)
         .with(path: "/delta/latest_cursor", method: :post)
         .and_return(cursor: "4")
 
       allow(api).to receive(:execute)
         .with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           path: "/delta",
           method: :get,
           query: { cursor: "4", limit: 100, offset: 0 },

--- a/spec/nylas/deltas_spec.rb
+++ b/spec/nylas/deltas_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Deltas do
+describe NylasV2::Deltas do
   it "safely inflates an account.running event" do
     data = {
       "deltas": [
@@ -27,7 +27,7 @@ describe Nylas::Deltas do
     expect(delta.date).to eql(Time.at(1_514_335_663))
     expect(delta.type).to eql "account.running"
     expect(delta.object).to eql "account"
-    expect(delta.model).to be_a Nylas::Account
+    expect(delta.model).to be_a NylasV2::Account
     expect(delta.id).to eql "dlt-09876"
     expect(delta.namespace_id).to eql "acc-2345"
     expect(delta.account_id).to eql "acc-2345"
@@ -77,7 +77,7 @@ describe Nylas::Deltas do
     delta = deltas.first
     expect(delta.date).to eql(Time.at(1_514_339_684))
     expect(delta.object).to eql("message")
-    expect(delta.model).to be_a Nylas::Message
+    expect(delta.model).to be_a NylasV2::Message
     expect(delta.model.id).to eql "msg-1234"
     expect(delta.model.thread_id).to eql "thread-098"
     expect(delta.model.received_date).to eql Time.at(1_514_339_665)
@@ -134,7 +134,7 @@ describe Nylas::Deltas do
         references: ["<evh5uy0shhpm5d0le89goor17-0@example.com>"]
       }
     )
-    expect(message_delta.model).to be_a(Nylas::Message)
+    expect(message_delta.model).to be_a(NylasV2::Message)
     expect(message_delta.id).to eq("message-id")
     expect(message_delta.account_id).to eq("acc-id")
     expect(message_delta.headers.in_reply_to).to eq("<evh5uy0shhpm5d0le89goor17-0@example.com>")
@@ -148,7 +148,7 @@ describe Nylas::Deltas do
       object: "event",
       id: "event-id"
     )
-    expect(event_delta.model).to be_a(Nylas::Event)
+    expect(event_delta.model).to be_a(NylasV2::Event)
     expect(event_delta.model.attributes.to_h).to include(
       account_id: "acc-id",
       object: "event",
@@ -172,7 +172,7 @@ describe Nylas::Deltas do
 
     expect(deltas.count).to eq(1)
     delta = deltas.last
-    expect(delta.model).to be_a(Nylas::Message)
+    expect(delta.model).to be_a(NylasV2::Message)
     expect(delta.attributes.to_h).to eq(
       object: "message"
     )
@@ -193,7 +193,7 @@ describe Nylas::Deltas do
     expect(deltas.count).to eq(1)
     delta = deltas.last
     expect(delta.id).to eq("some-id")
-    expect(delta.model).to be_a(Nylas::Event)
+    expect(delta.model).to be_a(NylasV2::Event)
     expect(delta.attributes.to_h).to eq(
       id: "some-id",
       object: "event"
@@ -216,7 +216,7 @@ describe Nylas::Deltas do
     expect(deltas.count).to eq(1)
     delta = deltas.last
     expect(delta.id).to eq("some-id")
-    expect(delta.model).to be_a(Nylas::Message)
+    expect(delta.model).to be_a(NylasV2::Message)
     expect(delta.attributes.to_h).to eq(
       id: "some-id",
       object: "message"

--- a/spec/nylas/draft_spec.rb
+++ b/spec/nylas/draft_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Draft do
+describe NylasV2::Draft do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
   end
@@ -30,8 +30,8 @@ describe Nylas::Draft do
   describe "update" do
     context "with `files` key" do
       it "if `files` present, remove from the payload and sets the proper file_ids key" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-        file = Nylas::File.new(id: "abc-123")
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+        file = NylasV2::File.new(id: "abc-123")
         data = {
           id: "draft-1234"
         }
@@ -43,7 +43,7 @@ describe Nylas::Draft do
         draft.update(subject: "Updated subject", files: [file])
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -57,7 +57,7 @@ describe Nylas::Draft do
 
     context "when `files` key does not exists" do
       it "does not set the file_ids key or make any further changes to the payload" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
         data = {
           id: "draft-1234"
         }
@@ -69,7 +69,7 @@ describe Nylas::Draft do
         draft.update(subject: "Updated subject")
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -85,7 +85,7 @@ describe Nylas::Draft do
         id: "draft-1234",
         version: 1
       }
-      api = instance_double(Nylas::API, execute: expected_response)
+      api = instance_double(NylasV2::API, execute: expected_response)
       data = {
         id: "draft-1234",
         version: 0
@@ -101,7 +101,7 @@ describe Nylas::Draft do
     end
 
     it "sends the version number if the user does not manually add it" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       data = {
         id: "draft-1234",
         subject: "This is a draft",
@@ -118,7 +118,7 @@ describe Nylas::Draft do
       draft.update(**updated)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/drafts/draft-1234",
         payload: JSON.dump(
@@ -133,8 +133,8 @@ describe Nylas::Draft do
   describe "#create" do
     context "when `files` key exists" do
       it "removes `files` from the payload and sets the proper file_ids key" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-        file = Nylas::File.new(id: "abc-123")
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+        file = NylasV2::File.new(id: "abc-123")
         data = {
           id: "draft-1234",
           files: [file]
@@ -147,7 +147,7 @@ describe Nylas::Draft do
         draft.create
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/drafts",
           payload: JSON.dump(
@@ -161,7 +161,7 @@ describe Nylas::Draft do
 
     context "when `files` key does not exists" do
       it "does nothing" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
         data = {
           id: "draft-1234"
         }
@@ -173,7 +173,7 @@ describe Nylas::Draft do
         draft.create
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/drafts",
           payload: JSON.dump(
@@ -188,8 +188,8 @@ describe Nylas::Draft do
   describe "save" do
     context "when `files` key exists" do
       it "removes `files` from the payload and sets the proper file_ids key" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-        file = Nylas::File.new(id: "abc-123")
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+        file = NylasV2::File.new(id: "abc-123")
         data = {
           id: "draft-1234",
           files: [file]
@@ -202,7 +202,7 @@ describe Nylas::Draft do
         draft.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -216,7 +216,7 @@ describe Nylas::Draft do
 
     context "when `files` key does not exists" do
       it "does nothing" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
         data = {
           id: "draft-1234"
         }
@@ -228,7 +228,7 @@ describe Nylas::Draft do
         draft.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/drafts/draft-1234",
           payload: JSON.dump(
@@ -244,7 +244,7 @@ describe Nylas::Draft do
         id: "draft-1234",
         version: 1
       }
-      api = instance_double(Nylas::API, execute: expected_response)
+      api = instance_double(NylasV2::API, execute: expected_response)
       data = {
         id: "draft-1234"
       }
@@ -261,7 +261,7 @@ describe Nylas::Draft do
 
   describe "#send!" do
     it "sends the payload if the draft was not created on the server" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       draft = described_class.from_hash({ reply_to_message_id: "mess-1234",
                                           to: [{ email: "to@example.com", name: "To Example" }],
                                           from: [{ email: "from@example.com", name: "From Example" }],
@@ -273,7 +273,7 @@ describe Nylas::Draft do
       draft.send!
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/send",
         payload: update_json,
@@ -282,7 +282,7 @@ describe Nylas::Draft do
     end
 
     it "includes tracking when sending the draft" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       draft = described_class.from_hash({ id: "draft-1234", "version": 5 }, api: api)
       draft.tracking = { opens: true, links: true, thread_replies: true, payload: "this is a payload" }
       allow(api).to receive(:execute)
@@ -290,7 +290,7 @@ describe Nylas::Draft do
       draft.send!
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/send",
         payload: JSON.dump(
@@ -305,7 +305,7 @@ describe Nylas::Draft do
 
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = { id: "drft-592", version: 0, object: "draft", account_id: "acc-9987", thread_id: "thread-1234",
                reply_to_message_id: "mess-1234", date: 1_513_276_982,
                to: [{ email: "to@example.com", name: "To Example" }],

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -55,7 +55,8 @@ describe Nylas::Event do
           minutes_before_event: "60",
           subject: "Test Event Notification",
           body: "Reminding you about our meeting."
-        }]
+        }],
+        visibility: "private"
       }
 
       event = described_class.from_json(JSON.dump(data), api: api)
@@ -97,6 +98,7 @@ describe Nylas::Event do
       expect(event.notifications[0].minutes_before_event).to be 60
       expect(event.notifications[0].subject).to eql "Test Event Notification"
       expect(event.notifications[0].body).to eql "Reminding you about our meeting."
+      expect(event.visibility).to eql "private"
     end
   end
 

--- a/spec/nylas/event_spec.rb
+++ b/spec/nylas/event_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-describe Nylas::Event do
+describe NylasV2::Event do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "event-8766",
         object: "event",
@@ -104,7 +104,7 @@ describe Nylas::Event do
 
   describe "busy?" do
     it "returns true when busy attribute from API return true" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         account_id: "acc-1234",
         busy: true,
@@ -117,7 +117,7 @@ describe Nylas::Event do
     end
 
     it "returns false when busy attribute from API return false" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         account_id: "acc-1234",
         busy: false,
@@ -132,7 +132,7 @@ describe Nylas::Event do
 
   describe "#read_only?" do
     it "returns true when read_only attribute from API return true" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         account_id: "acc-1234",
         read_only: true,
@@ -145,7 +145,7 @@ describe Nylas::Event do
     end
 
     it "returns false when read_only attribute from API return false" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         account_id: "acc-1234",
         read_only: false,
@@ -160,7 +160,7 @@ describe Nylas::Event do
 
   describe "#rsvp" do
     it "calls `Rsvp` with the given status and flag to notify_participants" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "event-123",
         account_id: "acc-1234",
@@ -168,12 +168,12 @@ describe Nylas::Event do
         calendar_id: "cal-0987"
       }
       rsvp = instance_double("Rsvp", save: nil)
-      allow(Nylas::Rsvp).to receive(:new).and_return(rsvp)
+      allow(NylasV2::Rsvp).to receive(:new).and_return(rsvp)
       event = described_class.from_json(JSON.dump(data), api: api)
 
       event.rsvp(:yes, notify_participants: true)
 
-      expect(Nylas::Rsvp).to have_received(:new).with(
+      expect(NylasV2::Rsvp).to have_received(:new).with(
         api: api,
         status: :yes,
         event_id: "event-123",
@@ -187,7 +187,7 @@ describe Nylas::Event do
   describe "account_id" do
     context "when saving" do
       it "is excluded from payload" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -200,7 +200,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -216,7 +216,7 @@ describe Nylas::Event do
   describe "object" do
     context "when saving" do
       it "is excluded from payload" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -228,7 +228,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -243,7 +243,7 @@ describe Nylas::Event do
   describe "id" do
     context "when saving" do
       it "is excluded from payload" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -254,7 +254,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -265,7 +265,7 @@ describe Nylas::Event do
       end
 
       it "sends the conferencing autocreate object even if settings is empty" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -282,7 +282,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -299,7 +299,7 @@ describe Nylas::Event do
       end
 
       it "sends the conferencing object if details alone is set" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -321,7 +321,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-id",
           payload: {
@@ -343,7 +343,7 @@ describe Nylas::Event do
       end
 
       it "throws an error if both conferencing details and autocreate are set" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -370,7 +370,7 @@ describe Nylas::Event do
       end
 
       it "throws an error if capacity is less than the amount of participants" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -385,7 +385,7 @@ describe Nylas::Event do
       end
 
       it "does not throw an error if capacity is -1" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -399,7 +399,7 @@ describe Nylas::Event do
       end
 
       it "does not throw an error if participants less than or equal to capacity" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           id: "event-id",
@@ -420,7 +420,7 @@ describe Nylas::Event do
   describe "reminder_minutes" do
     context "when saving" do
       it "is formatted properly if set to a numeric value" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           reminder_minutes: "20"
@@ -430,7 +430,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -441,7 +441,7 @@ describe Nylas::Event do
       end
 
       it "is left as-is if user already formatted properly" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           reminder_minutes: "[20]"
@@ -451,7 +451,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -462,7 +462,7 @@ describe Nylas::Event do
       end
 
       it "does not send reminder_minutes if unset" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           reminder_minutes: ""
@@ -472,7 +472,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {}.to_json,
@@ -485,7 +485,7 @@ describe Nylas::Event do
   describe "notify_participants" do
     context "when creating" do
       it "sends notify_participants in query params" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           account_id: "acc-1234",
@@ -498,7 +498,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -512,7 +512,7 @@ describe Nylas::Event do
       end
 
       it "sends nothing when `notify_participants` is not set" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute).and_return({})
         data = {
           account_id: "acc-1234",
@@ -524,7 +524,7 @@ describe Nylas::Event do
         event.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :post,
           path: "/events",
           payload: {
@@ -538,7 +538,7 @@ describe Nylas::Event do
 
     context "when updating" do
       it "sends notify_participants in query params" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute)
         data = {
           id: "event-8766",
@@ -552,7 +552,7 @@ describe Nylas::Event do
         event.update(location: "Somewhere else!")
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-8766",
           payload: {
@@ -565,7 +565,7 @@ describe Nylas::Event do
       end
 
       it "sends nothing when `notify_participants` is not set" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute)
         data = {
           id: "event-8766",
@@ -578,7 +578,7 @@ describe Nylas::Event do
         event.update(location: "Somewhere else!")
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/events/event-8766",
           payload: {
@@ -591,7 +591,7 @@ describe Nylas::Event do
 
     context "when deleting" do
       it "sends notify_participants in query params" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute)
         data = {
           id: "event-8766",
@@ -605,7 +605,7 @@ describe Nylas::Event do
         event.destroy
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :delete,
           path: "/events/event-8766",
           payload: nil,
@@ -616,7 +616,7 @@ describe Nylas::Event do
       end
 
       it "sends nothing when `notify_participants` is not set" do
-        api = instance_double(Nylas::API)
+        api = instance_double(NylasV2::API)
         allow(api).to receive(:execute)
         data = {
           id: "event-8766",
@@ -629,7 +629,7 @@ describe Nylas::Event do
         event.destroy
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :delete,
           path: "/events/event-8766",
           payload: nil,
@@ -641,7 +641,7 @@ describe Nylas::Event do
 
   describe "generating an ICS" do
     it "sends the event ID if set" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute).and_return({})
       data = {
         id: "event-id",
@@ -666,7 +666,7 @@ describe Nylas::Event do
     end
 
     it "sends the event object if event id is not set" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute).and_return({})
       data = {
         calendar_id: "cal-0987",
@@ -695,7 +695,7 @@ describe Nylas::Event do
     end
 
     it "throws an error if event has no calendar ID set" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute).and_return({})
       data = {
         title: "An Event",
@@ -711,7 +711,7 @@ describe Nylas::Event do
     end
 
     it "throws an error if event has no when object set" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       allow(api).to receive(:execute).and_return({})
       data = {
         calendar_id: "cal-0987",

--- a/spec/nylas/filter_attributes_spec.rb
+++ b/spec/nylas/filter_attributes_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::FilterAttributes do
+describe NylasV2::FilterAttributes do
   describe "#check" do
     context "when `attributes` and `allowed_attributes` are similar" do
       it "does not raise any error" do

--- a/spec/nylas/folder_spec.rb
+++ b/spec/nylas/folder_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Folder do
+describe NylasV2::Folder do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
   end
@@ -23,7 +23,7 @@ describe Nylas::Folder do
 
   describe "API operations" do
     it "sends a POST when saving a new folder" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       json = JSON.dump(display_name: "All Mail", name: "all")
       folder = described_class.from_json(json, api: api)
       allow(api).to receive(:execute).and_return({})
@@ -31,7 +31,7 @@ describe Nylas::Folder do
       folder.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/folders",
         payload: {
@@ -43,7 +43,7 @@ describe Nylas::Folder do
     end
 
     it "sends a PUT when updating an existing folder" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
                        object: "folder")
       folder = described_class.from_json(json, api: api)
@@ -54,7 +54,7 @@ describe Nylas::Folder do
       )
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/folders/folder_id",
         payload: {
@@ -65,7 +65,7 @@ describe Nylas::Folder do
     end
 
     it "sends a PUT when saving an existing folder" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
                        object: "folder")
       folder = described_class.from_json(json, api: api)
@@ -74,7 +74,7 @@ describe Nylas::Folder do
       folder.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/folders/folder_id",
         payload: {
@@ -86,7 +86,7 @@ describe Nylas::Folder do
     end
 
     it "sends a DELETE when deleting an existing folder" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       json = JSON.dump(id: "folder_id", display_name: "All Mail", name: "all", account_id: "acc-234",
                        object: "folder")
       folder = described_class.from_json(json, api: api)
@@ -95,7 +95,7 @@ describe Nylas::Folder do
       folder.destroy
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :delete,
         path: "/folders/folder_id",
         payload: nil,

--- a/spec/nylas/free_busy_collection_spec.rb
+++ b/spec/nylas/free_busy_collection_spec.rb
@@ -2,13 +2,13 @@
 
 require "spec_helper"
 
-describe Nylas::FreeBusyCollection do
+describe NylasV2::FreeBusyCollection do
   describe "#each" do
     it "returns collection of `FreeBusy` objects" do
       start_time = 1_609_439_400
       end_time = 1_640_975_400
       emails = ["test@example.com", "anothertest@example.com"]
-      api = instance_double("Nylas::API")
+      api = instance_double("NylasV2::API")
       free_busy_response = [
         {
           object: "free_busy",

--- a/spec/nylas/free_busy_spec.rb
+++ b/spec/nylas/free_busy_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::FreeBusy do
+describe NylasV2::FreeBusy do
   describe "#email" do
     it "reads and write value for email" do
       email = "test@example.com"

--- a/spec/nylas/http_client_spec.rb
+++ b/spec/nylas/http_client_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "webmock/rspec"
 
-describe Nylas::HttpClient do
+describe NylasV2::HttpClient do
   let(:full_json) do
     '{"snippet":"\u26a1\ufe0f Some text \ud83d","starred":false,"subject":"Updates"}'
   end
@@ -17,7 +17,7 @@ describe Nylas::HttpClient do
 
     it "raises if the JSON is unable to be deserialized" do
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
-      expect { nylas.parse_response("{{") }.to raise_error(Nylas::JsonParseError)
+      expect { nylas.parse_response("{{") }.to raise_error(NylasV2::JsonParseError)
     end
   end
 
@@ -38,7 +38,7 @@ describe Nylas::HttpClient do
       stub_request(:get, "https://api.nylas.com/contacts/1234")
         .to_return(status: 200, body: "abc", headers: { "Content-Type" => "Application/Json" })
 
-      expect { nylas.execute(method: :get, path: "/contacts/1234") }.to raise_error(Nylas::JsonParseError)
+      expect { nylas.execute(method: :get, path: "/contacts/1234") }.to raise_error(NylasV2::JsonParseError)
     end
 
     it "still throws an API error if content-type == application/json but response is not a json" do
@@ -47,7 +47,7 @@ describe Nylas::HttpClient do
       stub_request(:get, "https://api.nylas.com/contacts/1234")
         .to_return(status: 400, body: "abc", headers: { "Content-Type" => "Application/Json" })
 
-      expect { nylas.execute(method: :get, path: "/contacts/1234") }.to raise_error(Nylas::InvalidRequest)
+      expect { nylas.execute(method: :get, path: "/contacts/1234") }.to raise_error(NylasV2::InvalidRequest)
     end
 
     it "skips parsing when content-type is not JSON" do
@@ -62,7 +62,7 @@ describe Nylas::HttpClient do
   end
 
   describe "#execute" do
-    it "includes Nylas API Version in headers" do
+    it "includes NylasV2 API Version in headers" do
       supported_api_version = "2.5"
       nylas = described_class.new(app_id: "id", app_secret: "secret", access_token: "token")
       allow(RestClient::Request).to receive(:execute)
@@ -70,7 +70,7 @@ describe Nylas::HttpClient do
       nylas.execute(method: :get, path: "/contacts/1234/picture")
 
       expect(RestClient::Request).to have_received(:execute).with(
-        headers: hash_including("Nylas-API-Version" => supported_api_version),
+        headers: hash_including("NylasV2-API-Version" => supported_api_version),
         method: :get,
         payload: nil,
         timeout: 230,
@@ -91,21 +91,21 @@ describe Nylas::HttpClient do
 
   describe "HTTP errors" do
     http_codes_errors = {
-      400 => Nylas::InvalidRequest,
-      401 => Nylas::UnauthorizedRequest,
-      402 => Nylas::MessageRejected,
-      403 => Nylas::AccessDenied,
-      404 => Nylas::ResourceNotFound,
-      405 => Nylas::MethodNotAllowed,
-      410 => Nylas::ResourceRemoved,
-      418 => Nylas::TeapotError,
-      422 => Nylas::MailProviderError,
-      429 => Nylas::SendingQuotaExceeded,
-      500 => Nylas::InternalError,
-      501 => Nylas::EndpointNotYetImplemented,
-      502 => Nylas::BadGateway,
-      503 => Nylas::ServiceUnavailable,
-      504 => Nylas::RequestTimedOut
+      400 => NylasV2::InvalidRequest,
+      401 => NylasV2::UnauthorizedRequest,
+      402 => NylasV2::MessageRejected,
+      403 => NylasV2::AccessDenied,
+      404 => NylasV2::ResourceNotFound,
+      405 => NylasV2::MethodNotAllowed,
+      410 => NylasV2::ResourceRemoved,
+      418 => NylasV2::TeapotError,
+      422 => NylasV2::MailProviderError,
+      429 => NylasV2::SendingQuotaExceeded,
+      500 => NylasV2::InternalError,
+      501 => NylasV2::EndpointNotYetImplemented,
+      502 => NylasV2::BadGateway,
+      503 => NylasV2::ServiceUnavailable,
+      504 => NylasV2::RequestTimedOut
     }
 
     http_codes_errors.each do |code, error|
@@ -151,7 +151,7 @@ describe Nylas::HttpClient do
         .to_return(status: 429, body: error_json, headers: error_headers)
 
       expect { nylas.execute(method: :get, path: "/contacts") }
-        .to raise_error(an_instance_of(Nylas::SendingQuotaExceeded)
+        .to raise_error(an_instance_of(NylasV2::SendingQuotaExceeded)
                          .and(having_attributes(
                                 rate_limit: 500,
                                 rate_limit_reset: 10

--- a/spec/nylas/job_status_spec.rb
+++ b/spec/nylas/job_status_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::JobStatus do
+describe NylasV2::JobStatus do
   it "is not creatable" do
     expect(described_class).not_to be_creatable
   end

--- a/spec/nylas/label_spec.rb
+++ b/spec/nylas/label_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Label do
+describe NylasV2::Label do
   it "is not filterable" do
     expect(described_class).not_to be_filterable
   end

--- a/spec/nylas/message_spec.rb
+++ b/spec/nylas/message_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-describe Nylas::Message do
+describe NylasV2::Message do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = { id: "mess-8766", object: "message", account_id: "acc-1234", thread_id: "thread-1234",
                date: 1_511_302_748,
                to: [{ email: "to@example.com", name: "To Example" }],
@@ -131,7 +131,7 @@ describe Nylas::Message do
   describe "#save" do
     context "when `labels` key exists" do
       it "removes `labels` from the payload" do
-        api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+        api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
         data = {
           id: "message-1234",
           labels: [
@@ -147,7 +147,7 @@ describe Nylas::Message do
         message.save
 
         expect(api).to have_received(:execute).with(
-          auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+          auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
           method: :put,
           path: "/messages/message-1234",
           payload: JSON.dump(
@@ -159,7 +159,7 @@ describe Nylas::Message do
     end
 
     it "removes the folder node and replaces with folder_id" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       data = {
         id: "message-1234",
         folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
@@ -174,7 +174,7 @@ describe Nylas::Message do
       message.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -186,7 +186,7 @@ describe Nylas::Message do
       )
     end
     it "does not overwrite folder_id if set" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       data = {
         id: "message-1234",
         folder: { display_name: "Inbox", id: "folder-inbox", name: "inbox" },
@@ -202,7 +202,7 @@ describe Nylas::Message do
       message.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -217,7 +217,7 @@ describe Nylas::Message do
 
   describe "#update" do
     it "let's you set the starred, unread, folder, and label ids" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
 
       message.update(
@@ -228,7 +228,7 @@ describe Nylas::Message do
       )
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: JSON.dump(
@@ -243,7 +243,7 @@ describe Nylas::Message do
       )
     end
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(NylasV2::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       expect do
         message.update(subject: "A new subject!")
@@ -254,14 +254,14 @@ describe Nylas::Message do
   describe "update_folder" do
     it "moves message to new `folder`" do
       folder_id = "9999"
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(NylasV2::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       allow(api).to receive(:execute)
 
       message.update_folder(folder_id)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/messages/message-1234",
         payload: { folder_id: folder_id }.to_json,
@@ -272,7 +272,7 @@ describe Nylas::Message do
 
   describe "#expanded" do
     it "fetch or return expanded version of message" do
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(NylasV2::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       data = { id: "draft-1234",
                headers: { "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>",
@@ -290,7 +290,7 @@ describe Nylas::Message do
       expect(message.expanded.headers.references[0]).to eql "<evh5uy0shhpm5d0le89goor17-0@example.com>"
     end
     it "transfers api to attributes that need it" do
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(NylasV2::API, execute: "{}")
       message = described_class.from_json('{ "id": "message-1234" }', api: api)
       data = { id: "draft-1234",
                headers: { "In-Reply-To": "<evh5uy0shhpm5d0le89goor17-0@example.com>",

--- a/spec/nylas/model/attributes_spec.rb
+++ b/spec/nylas/model/attributes_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Model::Attributes do
+describe NylasV2::Model::Attributes do
   describe "#serialize_for_api" do
     it "rejects keys which are read_only" do
       test_json = {

--- a/spec/nylas/model_spec.rb
+++ b/spec/nylas/model_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Model do
+describe NylasV2::Model do
   def example_instance_json
     "{ }"
   end
@@ -20,19 +20,19 @@ describe Nylas::Model do
   describe "#save" do
     it "raises a NotImplementedError exception if the model is flagged as not updatable" do
       instance = NotUpdatableModel.from_hash({ id: "model-1234" }, api: api)
-      expect { instance.save }.to raise_error(Nylas::ModelNotUpdatableError)
+      expect { instance.save }.to raise_error(NylasV2::ModelNotUpdatableError)
     end
 
     it "raises a ModelNotCreatable exception if the model is new and is flagged as not creatable" do
       instance = NotCreatableModel.from_hash({}, api: api)
-      expect { instance.save }.to raise_error(Nylas::ModelNotCreatableError)
+      expect { instance.save }.to raise_error(NylasV2::ModelNotCreatableError)
     end
   end
 
   describe "#update" do
     it "raises a NotImplementedError exception if the model is flagged as read only" do
       instance = NotUpdatableModel.from_json(example_instance_json, api: api)
-      expect { instance.update(name: "other") }.to raise_error(Nylas::ModelNotUpdatableError)
+      expect { instance.update(name: "other") }.to raise_error(NylasV2::ModelNotUpdatableError)
     end
 
     it "raises a MissingFieldError if attempting to set a field that does not exist" do
@@ -40,7 +40,7 @@ describe Nylas::Model do
       instance = FullModel.new
       expect do
         instance.update(fake_attribute: "not real")
-      end.to raise_error(Nylas::ModelMissingFieldError, expected_message)
+      end.to raise_error(NylasV2::ModelMissingFieldError, expected_message)
     end
   end
 
@@ -57,7 +57,7 @@ describe Nylas::Model do
       instance.save_all_attributes
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         payload: {
           id: "1234",
@@ -83,13 +83,13 @@ describe Nylas::Model do
     it "raises a NotImplementedError exception if the model is flagged as not updatable" do
       instance = NotUpdatableModel.from_hash({ id: "model-1234" }, api: api)
 
-      expect { instance.save_all_attributes }.to raise_error(Nylas::ModelNotUpdatableError)
+      expect { instance.save_all_attributes }.to raise_error(NylasV2::ModelNotUpdatableError)
     end
 
     it "raises a ModelNotCreatable exception if the model is new and is flagged as not creatable" do
       instance = NotCreatableModel.from_hash({}, api: api)
 
-      expect { instance.save_all_attributes }.to raise_error(Nylas::ModelNotCreatableError)
+      expect { instance.save_all_attributes }.to raise_error(NylasV2::ModelNotCreatableError)
     end
   end
 
@@ -111,7 +111,7 @@ describe Nylas::Model do
       instance.update_all_attributes(**update_params)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         payload: update_params.to_json,
         path: "/collection/1234",
@@ -124,7 +124,7 @@ describe Nylas::Model do
     it "raises a NotImplementedError exception if the model is flagged as read only" do
       instance = NotUpdatableModel.from_json(example_instance_json, api: api)
 
-      expect { instance.update_all_attributes(name: "other") }.to raise_error(Nylas::ModelNotUpdatableError)
+      expect { instance.update_all_attributes(name: "other") }.to raise_error(NylasV2::ModelNotUpdatableError)
     end
 
     it "raises a MissingFieldError if attempting to set a field that does not exist" do
@@ -133,7 +133,7 @@ describe Nylas::Model do
 
       expect do
         instance.update_all_attributes(fake_attribute: "not real")
-      end.to raise_error(Nylas::ModelMissingFieldError, expected_message)
+      end.to raise_error(NylasV2::ModelMissingFieldError, expected_message)
     end
   end
 
@@ -150,7 +150,7 @@ describe Nylas::Model do
       instance.reload
       expect(instance.id).to eql "1234"
       expect(instance.string).to eql "I am real"
-      expect { instance.attributes[:fake_attribute] }.to raise_error Nylas::Registry::MissingKeyError
+      expect { instance.attributes[:fake_attribute] }.to raise_error NylasV2::Registry::MissingKeyError
     end
   end
 

--- a/spec/nylas/native_authentication_spec.rb
+++ b/spec/nylas/native_authentication_spec.rb
@@ -4,10 +4,10 @@ require "spec_helper"
 
 # rubocop:disable RSpec/MessageSpies
 
-describe Nylas::NativeAuthentication do
+describe NylasV2::NativeAuthentication do
   describe "#authenticate" do
     it "sets all scopes by default" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
@@ -20,7 +20,7 @@ describe Nylas::NativeAuthentication do
         method: :post, path: "/connect/token",
         payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
 
       expect(
         api.authenticate(
@@ -33,7 +33,7 @@ describe Nylas::NativeAuthentication do
     end
 
     it "allows arrays of one scope" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
@@ -46,7 +46,7 @@ describe Nylas::NativeAuthentication do
         method: :post, path: "/connect/token",
         payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
 
       expect(
         api.authenticate(
@@ -60,7 +60,7 @@ describe Nylas::NativeAuthentication do
     end
 
     it "allows arrays of two scopes" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
@@ -73,7 +73,7 @@ describe Nylas::NativeAuthentication do
         method: :post, path: "/connect/token",
         payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
 
       expect(
         api.authenticate(
@@ -87,7 +87,7 @@ describe Nylas::NativeAuthentication do
     end
 
     it "allows string scopes" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
@@ -100,7 +100,7 @@ describe Nylas::NativeAuthentication do
         method: :post, path: "/connect/token",
         payload: be_json_including("code" => 1234)
       ).and_return(access_token: "fake-token")
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
 
       expect(
         api.authenticate(

--- a/spec/nylas/neural_spec.rb
+++ b/spec/nylas/neural_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::Neural do
+describe NylasV2::Neural do
   describe "Clean Conversation" do
     let(:data) do
       [
@@ -13,7 +13,7 @@ describe Nylas::Neural do
           from: [
             {
               email: "swag@nylas.com",
-              name: "Nylas Swag"
+              name: "NylasV2 Swag"
             }
           ],
           id: "abc123",
@@ -32,7 +32,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
       clean_conversation = neural.clean_conversation(["abc123"])
 
@@ -52,9 +52,9 @@ describe Nylas::Neural do
     end
 
     it "Sends the options in the body" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
-      options = Nylas::NeuralMessageOptions.new(
+      options = NylasV2::NeuralMessageOptions.new(
         ignore_links: false,
         ignore_images: false,
         ignore_tables: false,
@@ -79,8 +79,8 @@ describe Nylas::Neural do
     end
 
     it "Parses the image correctly" do
-      api = instance_double(Nylas::API, execute: data)
-      files = instance_double(Nylas::Collection, find: Nylas::File.new(id: "file123"))
+      api = instance_double(NylasV2::API, execute: data)
+      files = instance_double(NylasV2::Collection, find: NylasV2::File.new(id: "file123"))
       allow(api).to receive(:files).and_return(files)
       neural = described_class.new(api: api)
       clean_conversation = neural.clean_conversation(["abc123"])
@@ -104,7 +104,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes the message request into Ruby objects" do
-      api = instance_double(Nylas::API, execute: [data])
+      api = instance_double(NylasV2::API, execute: [data])
       neural = described_class.new(api: api)
       sentiment = neural.sentiment_analysis_message(["abc123"])
 
@@ -125,7 +125,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes the text request into Ruby objects" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
       sentiment = neural.sentiment_analysis_text("This is some text")
 
@@ -151,11 +151,11 @@ describe Nylas::Neural do
         {
           account_id: "account123",
           body:
-            "This is the body<div>Nylas Swag</div><div>Software Engineer</div><div>123-456-8901</div>
+            "This is the body<div>NylasV2 Swag</div><div>Software Engineer</div><div>123-456-8901</div>
             <div>swag@nylas.com</div><img src='https://example.com/logo.png'
             alt='https://example.com/link.html'></a>",
           signature:
-            "Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com",
+            "NylasV2 Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com",
           contacts: {
             job_titles: ["Software Engineer"],
             links: [
@@ -168,7 +168,7 @@ describe Nylas::Neural do
             emails: ["swag@nylas.com"],
             names: [
               {
-                first_name: "Nylas",
+                first_name: "NylasV2",
                 last_name: "Swag"
               }
             ]
@@ -177,7 +177,7 @@ describe Nylas::Neural do
           from: [
             {
               email: "swag@nylas.com",
-              name: "Nylas Swag"
+              name: "NylasV2 Swag"
             }
           ],
           id: "abc123",
@@ -196,7 +196,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
       signature = neural.extract_signature(["abc123"])
 
@@ -209,7 +209,7 @@ describe Nylas::Neural do
       )
 
       expect(signature.length).to be(1)
-      expect(signature[0].signature).to eql("Nylas Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com")
+      expect(signature[0].signature).to eql("NylasV2 Swag\n\nSoftware Engineer\n\n123-456-8901\nswag@nylas.com")
       expect(signature[0].model_version).to eql("0.0.1")
       expect(signature[0].contacts.job_titles).to eql(["Software Engineer"])
       expect(signature[0].contacts.phone_numbers).to eql(["123-456-8901"])
@@ -218,14 +218,14 @@ describe Nylas::Neural do
       expect(signature[0].contacts.links[0].description).to eql("string")
       expect(signature[0].contacts.links[0].url).to eql("https://example.com/link.html")
       expect(signature[0].contacts.names.length).to be(1)
-      expect(signature[0].contacts.names[0].first_name).to eql("Nylas")
+      expect(signature[0].contacts.names[0].first_name).to eql("NylasV2")
       expect(signature[0].contacts.names[0].last_name).to eql("Swag")
     end
 
     it "Sends the options in the body" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
-      options = Nylas::NeuralMessageOptions.new(
+      options = NylasV2::NeuralMessageOptions.new(
         ignore_links: false,
         ignore_images: false,
         ignore_tables: false,
@@ -250,13 +250,13 @@ describe Nylas::Neural do
       )
     end
 
-    it "Converts signature contact object to a Nylas contact object" do
-      api = instance_double(Nylas::API, execute: data)
+    it "Converts signature contact object to a NylasV2 contact object" do
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
       signature = neural.extract_signature(["abc123"])
       contact = signature[0].contacts.to_contact_object
 
-      expect(contact.given_name).to eql("Nylas")
+      expect(contact.given_name).to eql("NylasV2")
       expect(contact.surname).to eql("Swag")
       expect(contact.job_title).to eql("Software Engineer")
       expect(contact.emails.length).to be(1)
@@ -283,7 +283,7 @@ describe Nylas::Neural do
         from: [
           {
             email: "swag@nylas.com",
-            name: "Nylas Swag"
+            name: "NylasV2 Swag"
           }
         ],
         id: "abc123",
@@ -300,7 +300,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API, execute: [data])
+      api = instance_double(NylasV2::API, execute: [data])
       neural = described_class.new(api: api)
       categorize = neural.categorize(["abc123"])
 
@@ -321,7 +321,7 @@ describe Nylas::Neural do
     end
 
     it "Re-categorizes the message" do
-      api = instance_double(Nylas::API, execute: [data])
+      api = instance_double(NylasV2::API, execute: [data])
       neural = described_class.new(api: api)
       allow(api).to receive(:neural).and_return(neural)
       categorize = neural.categorize(["abc123"])
@@ -350,7 +350,7 @@ describe Nylas::Neural do
     end
 
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API, execute: data)
+      api = instance_double(NylasV2::API, execute: data)
       neural = described_class.new(api: api)
       ocr = neural.ocr_request("abc123")
 

--- a/spec/nylas/new_message_spec.rb
+++ b/spec/nylas/new_message_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::NewMessage do
+describe NylasV2::NewMessage do
   describe "#send!" do
     data = {
       reply_to_message_id: "mess-1234",
@@ -18,7 +18,7 @@ describe Nylas::NewMessage do
     }
 
     it "sends the message directly" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
 
       allow(api).to receive(:send!)
 

--- a/spec/nylas/outbox_job_status_spec.rb
+++ b/spec/nylas/outbox_job_status_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::OutboxJobStatus do
+describe NylasV2::OutboxJobStatus do
   it "Deserializes all the attributes into Ruby objects" do
     data = { job_status_id: "job-status-123", status: "pending",
              original_data: { send_at: 1649179701, retry_limit_datetime: 1649266101,

--- a/spec/nylas/outbox_message_spec.rb
+++ b/spec/nylas/outbox_message_spec.rb
@@ -2,9 +2,9 @@
 
 require "spec_helper"
 
-describe Nylas::OutboxMessage do
+describe NylasV2::OutboxMessage do
   it "Deserializes all the attributes into Ruby objects" do
-    api = instance_double(Nylas::API)
+    api = instance_double(NylasV2::API)
     data = { send_at: 1649179701, retry_limit_datetime: 1649266101, original_send_at: 1649179701,
              account_id: "acc-9987", thread_id: "thread-1234", reply_to_message_id: "mess-1234",
              date: 1_513_276_982, to: [{ email: "to@example.com", name: "To Example" }],

--- a/spec/nylas/outbox_spec.rb
+++ b/spec/nylas/outbox_spec.rb
@@ -3,8 +3,8 @@
 require "spec_helper"
 require "date"
 
-describe Nylas::Outbox do
-  let(:api) { instance_double(Nylas::API) }
+describe NylasV2::Outbox do
+  let(:api) { instance_double(NylasV2::API) }
   let(:outbox) { described_class.new(api: api) }
   let(:tomorrow) { Date.today + 1 }
   let(:day_after) { Date.today + 2 }
@@ -15,7 +15,7 @@ describe Nylas::Outbox do
 
   describe "standard operations" do
     let(:draft) do
-      Nylas::Draft.new(to: [{ email: "not-a-real-email@example.com", name: "Example" }],
+      NylasV2::Draft.new(to: [{ email: "not-a-real-email@example.com", name: "Example" }],
                        subject: "A new draft!",
                        metadata: { sdk: "Ruby SDK" })
     end

--- a/spec/nylas/raw_message_spec.rb
+++ b/spec/nylas/raw_message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::RawMessage do
+describe NylasV2::RawMessage do
   describe ".#send!" do
     it "calls execute on api with params" do
       message_string = "MIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\n" \

--- a/spec/nylas/room_resource_spec.rb
+++ b/spec/nylas/room_resource_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::RoomResource do
+describe NylasV2::RoomResource do
   it "is not creatable" do
     expect(described_class).not_to be_creatable
   end
@@ -49,13 +49,13 @@ describe Nylas::RoomResource do
 
   context "when getting" do
     it "makes a call to the /resources endpoint" do
-      api = instance_double(Nylas::API, execute: "{}")
-      resource = Nylas::Collection.new(model: described_class, api: api)
+      api = instance_double(NylasV2::API, execute: "{}")
+      resource = NylasV2::Collection.new(model: described_class, api: api)
 
       api.execute(resource.to_be_executed)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :get,
         path: "/resources",
         headers: {},

--- a/spec/nylas/scheduler_collection_spec.rb
+++ b/spec/nylas/scheduler_collection_spec.rb
@@ -2,11 +2,11 @@
 
 require "spec_helper"
 
-describe Nylas::SchedulerCollection do
+describe NylasV2::SchedulerCollection do
   describe "ProviderAvailability" do
     it "(getGoogleAvailability) should call the correct endpoint" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
       scheduler_collection.get_google_availability
 
@@ -17,8 +17,8 @@ describe Nylas::SchedulerCollection do
     end
 
     it "(getOffice365Availability) should call the correct endpoint" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
       scheduler_collection.get_office_365_availability
 
@@ -43,8 +43,8 @@ describe Nylas::SchedulerCollection do
         created_at: "2021-06-24",
         modified_at: "2021-06-24"
       }
-      api = instance_double(Nylas::API, execute: scheduler_json)
-      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+      api = instance_double(NylasV2::API, execute: scheduler_json)
+      scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
       scheduler = scheduler_collection.get_page_slug("test-slug")
 
@@ -73,8 +73,8 @@ describe Nylas::SchedulerCollection do
           start: 1636728347
         }
       ]
-      api = instance_double(Nylas::API, execute: scheduler_time_slots)
-      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+      api = instance_double(NylasV2::API, execute: scheduler_time_slots)
+      scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
       timeslots = scheduler_collection.get_available_time_slots("test-slug")
 
@@ -92,8 +92,8 @@ describe Nylas::SchedulerCollection do
     end
 
     it "cancel booking" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"))
-      scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"))
+      scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
       scheduler_collection.cancel_booking("test-slug", "test-edit-hash", "test")
 
@@ -125,17 +125,17 @@ describe Nylas::SchedulerCollection do
           start_time: 1636728347,
           title: "Test Booking"
         }
-        api = instance_double(Nylas::API, execute: booking_confirmation)
-        scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+        api = instance_double(NylasV2::API, execute: booking_confirmation)
+        scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
-        slot = Nylas::SchedulerTimeSlot.new(
+        slot = NylasV2::SchedulerTimeSlot.new(
           account_id: "test-account-id",
           calendar_id: "test-calendar-id",
           emails: ["recipient@example.com"],
           start: Time.at(1636728347),
           end: Time.at(1636731958)
         )
-        timeslot_to_book = Nylas::SchedulerBookingRequest.new(
+        timeslot_to_book = NylasV2::SchedulerBookingRequest.new(
           additional_values: {
             test: "yes"
           },
@@ -207,8 +207,8 @@ describe Nylas::SchedulerCollection do
           start_time: 1636728347,
           title: "Test Booking"
         }
-        api = instance_double(Nylas::API, execute: booking_confirmation)
-        scheduler_collection = described_class.new(model: Nylas::Scheduler, api: api)
+        api = instance_double(NylasV2::API, execute: booking_confirmation)
+        scheduler_collection = described_class.new(model: NylasV2::Scheduler, api: api)
 
         booking_confirmation = scheduler_collection.confirm_booking("test-slug", "test-edit-hash")
 

--- a/spec/nylas/scheduler_spec.rb
+++ b/spec/nylas/scheduler_spec.rb
@@ -2,15 +2,15 @@
 
 require "spec_helper"
 
-describe Nylas::Scheduler do
+describe NylasV2::Scheduler do
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: 123,
         app_client_id: "test-client-id",
@@ -30,7 +30,7 @@ describe Nylas::Scheduler do
       expect(scheduler.id).to be 123
       expect(scheduler.app_client_id).to eql "test-client-id"
       expect(scheduler.app_organization_id).to be 0
-      expect(scheduler.config).to be_a(Nylas::SchedulerConfig)
+      expect(scheduler.config).to be_a(NylasV2::SchedulerConfig)
       expect(scheduler.config.timezone).to eql "America/Los_Angeles"
       expect(scheduler.edit_token).to eql "token"
       expect(scheduler.name).to eql "Test"
@@ -40,12 +40,12 @@ describe Nylas::Scheduler do
     end
 
     it "uses 'api.schedule.nylas.com' endpoint" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
 
       scheduler = api.scheduler
 
@@ -55,12 +55,12 @@ describe Nylas::Scheduler do
 
   describe "saving" do
     it "POST with no ID set" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         app_client_id: "test-client-id",
         app_organization_id: 0,
@@ -79,7 +79,7 @@ describe Nylas::Scheduler do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :post,
         path: "/manage/pages",
         payload: JSON.dump(
@@ -99,12 +99,12 @@ describe Nylas::Scheduler do
     end
 
     it "PUT with ID set" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: 123,
         app_client_id: "test-client-id",
@@ -124,7 +124,7 @@ describe Nylas::Scheduler do
       scheduler.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/manage/pages/123",
         payload: JSON.dump(
@@ -146,12 +146,12 @@ describe Nylas::Scheduler do
 
   describe "get available calendars" do
     it "makes a request with an ID present" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: 123
       }
@@ -167,12 +167,12 @@ describe Nylas::Scheduler do
     end
 
     it "throws an error if no ID present" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       scheduler = described_class.from_json(JSON.dump({}), api: api)
       allow(api).to receive(:execute).and_return({})
 
@@ -184,12 +184,12 @@ describe Nylas::Scheduler do
 
   describe "upload image" do
     it "makes a request with an ID present" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       data = {
         id: 123
       }
@@ -209,12 +209,12 @@ describe Nylas::Scheduler do
     end
 
     it "throws an error if no ID present" do
-      client = Nylas::HttpClient.new(
+      client = NylasV2::HttpClient.new(
         app_id: "not-real",
         app_secret: "also-not-real",
         access_token: "seriously-unreal"
       )
-      api = Nylas::API.new(client: client)
+      api = NylasV2::API.new(client: client)
       scheduler = described_class.from_json(JSON.dump({}), api: api)
       allow(api).to receive(:execute).and_return({})
 

--- a/spec/nylas/send_grid_verified_status_spec.rb
+++ b/spec/nylas/send_grid_verified_status_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::SendGridVerifiedStatus do
+describe NylasV2::SendGridVerifiedStatus do
   it "Deserializes all the attributes into Ruby objects" do
     data = { domain_verified: true, sender_verified: true }
 

--- a/spec/nylas/thread_spec.rb
+++ b/spec/nylas/thread_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Thread do
+describe NylasV2::Thread do
   it "is filterable" do
     expect(described_class).to be_filterable
   end
@@ -16,7 +16,7 @@ describe Nylas::Thread do
   end
 
   it "can be deserialized from JSON" do
-    api = instance_double(Nylas::API)
+    api = instance_double(NylasV2::API)
     json = JSON.dump(id: "thread-2345", account_id: "acc-1234", draft_ids: ["dra-987"],
                      first_message_timestamp: 1_510_080_143, has_attachments: false,
                      labels: [{ display_name: "All Mail", id: "label-all-mail", name: "all" },
@@ -79,14 +79,14 @@ describe Nylas::Thread do
   describe "update_folder" do
     it "moves thread to new `folder`" do
       folder_id = "9999"
-      api = instance_double(Nylas::API, execute: "{}")
+      api = instance_double(NylasV2::API, execute: "{}")
       thread = described_class.from_json('{ "id": "thread-1234" }', api: api)
       allow(api).to receive(:execute)
 
       thread.update_folder(folder_id)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/threads/thread-1234",
         payload: { folder_id: folder_id }.to_json,
@@ -97,7 +97,7 @@ describe Nylas::Thread do
 
   describe "#update" do
     it "let's you set the starred, unread, folder, and label ids" do
-      api =  instance_double(Nylas::API, execute: {})
+      api =  instance_double(NylasV2::API, execute: {})
       thread = described_class.from_json('{ "id": "thread-1234" }', api: api)
 
       thread.update(
@@ -108,7 +108,7 @@ describe Nylas::Thread do
       )
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BEARER,
+        auth_method: NylasV2::HttpClient::AuthMethod::BEARER,
         method: :put,
         path: "/threads/thread-1234",
         payload: JSON.dump(
@@ -122,7 +122,7 @@ describe Nylas::Thread do
     end
 
     it "raises an argument error if the data has any keys that aren't allowed to be updated" do
-      api =  instance_double(Nylas::API, execute: "{}")
+      api =  instance_double(NylasV2::API, execute: "{}")
       thread = described_class.from_json('{ "id": "thread-1234" }', api: api)
       expect do
         thread.update(subject: "A new subject!")

--- a/spec/nylas/webhook_spec.rb
+++ b/spec/nylas/webhook_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe Nylas::Webhook do
+describe NylasV2::Webhook do
   it "is creatable" do
     expect(described_class).to be_creatable
   end
@@ -25,7 +25,7 @@ describe Nylas::Webhook do
 
   describe ".from_json" do
     it "Deserializes all the attributes into Ruby objects" do
-      api = instance_double(Nylas::API)
+      api = instance_double(NylasV2::API)
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -48,7 +48,7 @@ describe Nylas::Webhook do
 
   describe "#create" do
     it "Serializes all non-read-only attributes" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         application_id: "app-123",
         callback_url: "https://url.com/callback",
@@ -62,7 +62,7 @@ describe Nylas::Webhook do
       webhook.create
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/a/app-987/webhooks",
         payload: JSON.dump(
@@ -77,7 +77,7 @@ describe Nylas::Webhook do
 
   describe "update" do
     it "Serializes only state" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -92,7 +92,7 @@ describe Nylas::Webhook do
       webhook.update(state: WebhookState::INACTIVE)
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/a/app-987/webhooks/webhook-123",
         payload: JSON.dump(
@@ -103,7 +103,7 @@ describe Nylas::Webhook do
     end
 
     it "Throws an error if update was called with something other than just state" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -123,7 +123,7 @@ describe Nylas::Webhook do
 
   describe "save" do
     it "Creates if no id exists" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         application_id: "app-123",
         callback_url: "https://url.com/callback",
@@ -137,7 +137,7 @@ describe Nylas::Webhook do
       webhook.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :post,
         path: "/a/app-987/webhooks",
         payload: JSON.dump(
@@ -150,7 +150,7 @@ describe Nylas::Webhook do
     end
 
     it "Updates if id exists" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -165,7 +165,7 @@ describe Nylas::Webhook do
       webhook.save
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :put,
         path: "/a/app-987/webhooks/webhook-123",
         payload: JSON.dump(
@@ -178,7 +178,7 @@ describe Nylas::Webhook do
 
   describe "#destroy" do
     it "Deletes the webhook on the API" do
-      api = instance_double(Nylas::API, execute: JSON.parse("{}"), app_id: "app-987")
+      api = instance_double(NylasV2::API, execute: JSON.parse("{}"), app_id: "app-987")
       data = {
         id: "webhook-123",
         application_id: "app-123",
@@ -193,7 +193,7 @@ describe Nylas::Webhook do
       webhook.destroy
 
       expect(api).to have_received(:execute).with(
-        auth_method: Nylas::HttpClient::AuthMethod::BASIC,
+        auth_method: NylasV2::HttpClient::AuthMethod::BASIC,
         method: :delete,
         path: "/a/app-987/webhooks/webhook-123",
         payload: nil,

--- a/spec/nylas/when_spec.rb
+++ b/spec/nylas/when_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Nylas::When do
+  describe "valid" do
+    it "throws if a timezone is set to a non-IANA string" do
+      when_obj = described_class.new(timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
+
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "throws if a start_timezone is set to a non-IANA string" do
+      when_obj = described_class.new(start_timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
+
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "throws if a end_timezone is set to a non-IANA string" do
+      when_obj = described_class.new(end_timezone: "Non IANA")
+      error_msg = "The timezone provided (Non IANA) is not a valid IANA timezone database name"
+
+      expect { when_obj.valid? }.to raise_error(ArgumentError, error_msg)
+    end
+
+    it "does not throw if timezone is set validly (IANA string)" do
+      when_obj = described_class.new(timezone: "America/New_York")
+
+      expect { when_obj.valid? }.not_to raise_error
+    end
+
+    it "does not throw if no timezone set" do
+      when_obj = described_class.new
+
+      expect { when_obj.valid? }.not_to raise_error
+    end
+  end
+end

--- a/spec/nylas/when_spec.rb
+++ b/spec/nylas/when_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Nylas::When do
+describe NylasV2::When do
   describe "valid" do
     it "throws if a timezone is set to a non-IANA string" do
       when_obj = described_class.new(timezone: "Non IANA")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@
 require "simplecov"
 SimpleCov.start
 
+require "simplecov-cobertura"
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
 require "nylas"
 require "pry"
 require "webmock/rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ require "rspec-json_matcher"
 RSpec.configuration.include RSpec::JsonMatcher
 
 class FakeAPI
-  def execute(method:, path:, payload: nil, query: {}, auth_method: Nylas::HttpClient::AuthMethod::BEARER)
+  def execute(method:, path:, payload: nil, query: {}, auth_method: NylasV2::HttpClient::AuthMethod::BEARER)
     requests.push(method: method, path: path, payload: payload, query: query, auth_method: auth_method)
   end
 
@@ -26,7 +26,7 @@ end
 # Illustrates all the types and such a model can be built out of. Used for testing the generic Model
 # functionality without conflating it with actual Models
 class FullModel
-  include Nylas::Model
+  include NylasV2::Model
   self.creatable = true
   self.showable = true
   self.listable = true
@@ -60,7 +60,7 @@ class FullModel
 end
 
 class NotCreatableModel
-  include Nylas::Model
+  include NylasV2::Model
   self.resources_path = "/not_creatable_collection"
 
   attribute :id, :string
@@ -78,7 +78,7 @@ class NotCreatableModel
 end
 
 class NotUpdatableModel
-  include Nylas::Model
+  include NylasV2::Model
   self.resources_path = "/not_updatable_collection"
 
   attribute :id, :string
@@ -96,7 +96,7 @@ class NotUpdatableModel
 end
 
 class NonFilterableModel < FullModel
-  include Nylas::Model
+  include NylasV2::Model
   self.resources_path = "/non_filterable_collection"
 
   attribute :id, :string


### PR DESCRIPTION
# Description
This PR just does a bulk find and replace for all `Nylas` constants to `NylasV2` so that we can bundle this gem along with its v6 version from Nylas

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.